### PR TITLE
feat: Add XRPC endpoints for communities, members, and records

### DIFF
--- a/lexicons/community.opensocial.approveMember.json
+++ b/lexicons/community.opensocial.approveMember.json
@@ -1,0 +1,34 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.approveMember",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Approve a pending member's join request.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communityDid", "adminDid", "userDid"],
+          "properties": {
+            "communityDid": { "type": "string", "format": "did" },
+            "adminDid": { "type": "string", "format": "did" },
+            "userDid": { "type": "string", "format": "did" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" },
+        { "name": "NoPendingRequest" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.createRecord.json
+++ b/lexicons/community.opensocial.createRecord.json
@@ -1,0 +1,40 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.createRecord",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Create a record in a community's PDS repo on behalf of a member.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communityDid", "userDid", "collection", "record"],
+          "properties": {
+            "communityDid": { "type": "string", "format": "did" },
+            "userDid": { "type": "string", "format": "did" },
+            "collection": { "type": "string" },
+            "record": { "type": "unknown" },
+            "rkey": { "type": "string" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["uri", "cid"],
+          "properties": {
+            "uri": { "type": "string", "format": "at-uri" },
+            "cid": { "type": "string" }
+          }
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" },
+        { "name": "InvalidInput" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.deleteCommunity.json
+++ b/lexicons/community.opensocial.deleteCommunity.json
@@ -1,0 +1,33 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.deleteCommunity",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Delete a community. Only the sole remaining admin can delete.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communityDid", "adminDid"],
+          "properties": {
+            "communityDid": { "type": "string", "format": "did" },
+            "adminDid": { "type": "string", "format": "did" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" },
+        { "name": "MultipleAdmins" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.deleteRecord.json
+++ b/lexicons/community.opensocial.deleteRecord.json
@@ -1,0 +1,35 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.deleteRecord",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Delete a record from a community's PDS repo.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communityDid", "userDid", "collection", "rkey"],
+          "properties": {
+            "communityDid": { "type": "string", "format": "did" },
+            "userDid": { "type": "string", "format": "did" },
+            "collection": { "type": "string" },
+            "rkey": { "type": "string" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" },
+        { "name": "RecordNotFound" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.getCommunity.json
+++ b/lexicons/community.opensocial.getCommunity.json
@@ -1,0 +1,51 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.getCommunity",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get details about a community.",
+      "parameters": {
+        "type": "params",
+        "required": ["did"],
+        "properties": {
+          "did": { "type": "string", "format": "did" },
+          "userDid": { "type": "string", "format": "did" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["community", "isAdmin"],
+          "properties": {
+            "community": {
+              "type": "object",
+              "required": ["did", "handle", "displayName", "description", "type", "admins", "createdAt", "memberCount"],
+              "properties": {
+                "did": { "type": "string", "format": "did" },
+                "handle": { "type": "string" },
+                "displayName": { "type": "string" },
+                "description": { "type": "string" },
+                "guidelines": { "type": "string" },
+                "type": { "type": "string" },
+                "avatar": { "type": "unknown" },
+                "banner": { "type": "unknown" },
+                "admins": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "createdAt": { "type": "string", "format": "datetime" },
+                "memberCount": { "type": "integer" }
+              }
+            },
+            "isAdmin": { "type": "boolean" }
+          }
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.getMembers.json
+++ b/lexicons/community.opensocial.getMembers.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.getMembers",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List members of a community.",
+      "parameters": {
+        "type": "params",
+        "required": ["communityDid"],
+        "properties": {
+          "communityDid": { "type": "string", "format": "did" },
+          "userDid": { "type": "string", "format": "did" },
+          "limit": { "type": "integer", "default": 50, "minimum": 1, "maximum": 100 },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["members", "total"],
+          "properties": {
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "did": { "type": "string", "format": "did" },
+                  "handle": { "type": "string" },
+                  "displayName": { "type": "string" },
+                  "avatar": { "type": "string" },
+                  "isAdmin": { "type": "boolean" },
+                  "confirmedAt": { "type": "string", "format": "datetime" }
+                }
+              }
+            },
+            "cursor": { "type": "string" },
+            "total": { "type": "integer" }
+          }
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.getPendingMembers.json
+++ b/lexicons/community.opensocial.getPendingMembers.json
@@ -1,0 +1,45 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.getPendingMembers",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List pending member requests for a community (admin only).",
+      "parameters": {
+        "type": "params",
+        "required": ["communityDid", "adminDid"],
+        "properties": {
+          "communityDid": { "type": "string", "format": "did" },
+          "adminDid": { "type": "string", "format": "did" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["members"],
+          "properties": {
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["userDid", "requestedAt"],
+                "properties": {
+                  "userDid": { "type": "string", "format": "did" },
+                  "requestedAt": { "type": "string", "format": "datetime" },
+                  "handle": { "type": "string" },
+                  "displayName": { "type": "string" },
+                  "avatar": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.getPermissions.json
+++ b/lexicons/community.opensocial.getPermissions.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.getPermissions",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get permissions and user roles for a community.",
+      "parameters": {
+        "type": "params",
+        "required": ["communityDid"],
+        "properties": {
+          "communityDid": { "type": "string", "format": "did" },
+          "userDid": { "type": "string", "format": "did" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["permissions", "userRoles"],
+          "properties": {
+            "permissions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["collection", "canCreate", "canRead", "canUpdate", "canDelete"],
+                "properties": {
+                  "collection": { "type": "string" },
+                  "canCreate": { "type": "string" },
+                  "canRead": { "type": "string" },
+                  "canUpdate": { "type": "string" },
+                  "canDelete": { "type": "string" }
+                }
+              }
+            },
+            "userRoles": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.getRecord.json
+++ b/lexicons/community.opensocial.getRecord.json
@@ -1,0 +1,37 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.getRecord",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get a specific record from a community's collection.",
+      "parameters": {
+        "type": "params",
+        "required": ["communityDid", "collection", "rkey"],
+        "properties": {
+          "communityDid": { "type": "string", "format": "did" },
+          "collection": { "type": "string" },
+          "rkey": { "type": "string" },
+          "userDid": { "type": "string", "format": "did" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["uri", "cid", "value"],
+          "properties": {
+            "uri": { "type": "string", "format": "at-uri" },
+            "cid": { "type": "string" },
+            "value": { "type": "unknown" }
+          }
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" },
+        { "name": "RecordNotFound" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.joinCommunity.json
+++ b/lexicons/community.opensocial.joinCommunity.json
@@ -1,0 +1,46 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.joinCommunity",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Join a community. For open communities, joins immediately. For admin-approved, submits a request.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communityDid", "userDid"],
+          "properties": {
+            "communityDid": { "type": "string", "format": "did" },
+            "userDid": { "type": "string", "format": "did" },
+            "membershipCid": { "type": "string" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["status", "message"],
+          "properties": {
+            "status": { "type": "string" },
+            "message": { "type": "string" },
+            "membership": {
+              "type": "object",
+              "properties": {
+                "communityDid": { "type": "string", "format": "did" },
+                "memberDid": { "type": "string", "format": "did" },
+                "joinedAt": { "type": "string", "format": "datetime" }
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "AlreadyMember" },
+        { "name": "AlreadyPending" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.leaveCommunity.json
+++ b/lexicons/community.opensocial.leaveCommunity.json
@@ -1,0 +1,33 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.leaveCommunity",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Leave a community.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communityDid", "userDid"],
+          "properties": {
+            "communityDid": { "type": "string", "format": "did" },
+            "userDid": { "type": "string", "format": "did" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "NotMember" },
+        { "name": "CannotLeaveAsAdmin" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.listRecords.json
+++ b/lexicons/community.opensocial.listRecords.json
@@ -1,0 +1,47 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.listRecords",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List records in a community's collection.",
+      "parameters": {
+        "type": "params",
+        "required": ["communityDid", "collection"],
+        "properties": {
+          "communityDid": { "type": "string", "format": "did" },
+          "collection": { "type": "string" },
+          "limit": { "type": "integer", "default": 50, "minimum": 1, "maximum": 100 },
+          "cursor": { "type": "string" },
+          "userDid": { "type": "string", "format": "did" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["records"],
+          "properties": {
+            "records": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["uri", "cid", "value"],
+                "properties": {
+                  "uri": { "type": "string", "format": "at-uri" },
+                  "cid": { "type": "string" },
+                  "value": { "type": "unknown" }
+                }
+              }
+            },
+            "cursor": { "type": "string" }
+          }
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.putRecord.json
+++ b/lexicons/community.opensocial.putRecord.json
@@ -1,0 +1,40 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.putRecord",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Put (create or update) a record in a community's PDS repo.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communityDid", "userDid", "collection", "rkey", "record"],
+          "properties": {
+            "communityDid": { "type": "string", "format": "did" },
+            "userDid": { "type": "string", "format": "did" },
+            "collection": { "type": "string" },
+            "rkey": { "type": "string" },
+            "record": { "type": "unknown" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["uri", "cid"],
+          "properties": {
+            "uri": { "type": "string", "format": "at-uri" },
+            "cid": { "type": "string" }
+          }
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" },
+        { "name": "InvalidInput" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.rejectMember.json
+++ b/lexicons/community.opensocial.rejectMember.json
@@ -1,0 +1,34 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.rejectMember",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Reject a pending member's join request.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communityDid", "adminDid", "userDid"],
+          "properties": {
+            "communityDid": { "type": "string", "format": "did" },
+            "adminDid": { "type": "string", "format": "did" },
+            "userDid": { "type": "string", "format": "did" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" },
+        { "name": "NoPendingRequest" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.removeMember.json
+++ b/lexicons/community.opensocial.removeMember.json
@@ -1,0 +1,35 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.removeMember",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Remove a member from a community (admin only).",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communityDid", "adminDid", "memberDid"],
+          "properties": {
+            "communityDid": { "type": "string", "format": "did" },
+            "adminDid": { "type": "string", "format": "did" },
+            "memberDid": { "type": "string", "format": "did" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      "errors": [
+        { "name": "CommunityNotFound" },
+        { "name": "PermissionDenied" },
+        { "name": "MemberNotFound" },
+        { "name": "CannotRemoveAdmin" }
+      ]
+    }
+  }
+}

--- a/lexicons/community.opensocial.searchCommunities.json
+++ b/lexicons/community.opensocial.searchCommunities.json
@@ -1,0 +1,47 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.searchCommunities",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Search for communities.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "query": { "type": "string" },
+          "userDid": { "type": "string", "format": "did" },
+          "limit": { "type": "integer", "default": 25, "maximum": 100 },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["communities"],
+          "properties": {
+            "communities": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["did", "handle", "displayName", "type", "memberCount"],
+                "properties": {
+                  "did": { "type": "string", "format": "did" },
+                  "handle": { "type": "string" },
+                  "displayName": { "type": "string" },
+                  "type": { "type": "string" },
+                  "isAdmin": { "type": "boolean" },
+                  "memberCount": { "type": "integer" }
+                }
+              }
+            },
+            "cursor": { "type": "string" }
+          }
+        }
+      },
+      "errors": [
+        { "name": "QueryTooShort" }
+      ]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@atproto/api": "^0.13.35",
         "@atproto/identity": "^0.4.12",
         "@atproto/oauth-client-node": "^0.3.13",
+        "@atproto/xrpc-server": "^0.10.20",
         "@types/cookie-parser": "^1.4.10",
         "@types/multer": "^2.0.0",
         "bcrypt": "^6.0.0",
@@ -204,6 +205,22 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@atproto/common": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@atproto/common/-/common-0.5.16.tgz",
+      "integrity": "sha512-DTWgaVlDJN3zDxJ3agZK3pbiSZc+z8QQe9iy15sIuorLrceIp4kHXMO/QqjWBXnmLVTd6+/5BVDzex5amYc0rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.20",
+        "@atproto/lex-cbor": "^0.0.16",
+        "@atproto/lex-data": "^0.0.15",
+        "multiformats": "^9.9.0",
+        "pino": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=18.7.0"
+      }
+    },
     "node_modules/@atproto/common-web": {
       "version": "0.4.21",
       "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.21.tgz",
@@ -232,6 +249,68 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@atproto/common/node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@atproto/common/node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@atproto/common/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto/common/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto/common/node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@atproto/common/node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/@atproto/crypto": {
@@ -328,6 +407,28 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@atproto/lex-cbor": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-cbor/-/lex-cbor-0.0.16.tgz",
+      "integrity": "sha512-x3NTvOX5/4Wh7uk8RNJpUJqZjcWRSUYDYRJ6VZPLmp/CAnsMySmBAinBu/dva/1hqS3C1oiYz258x6bRYpKJ4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.15",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/lex-client": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-client/-/lex-client-0.0.20.tgz",
+      "integrity": "sha512-K6x+kGWs67olnv1sEasI4NqlUJ+Gd1N9Rv1c6WkIqQnZff8WF1HDUyg3SpmGcYBG4pPPoeCmY5c9go/Box8OQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.15",
+        "@atproto/lex-json": "^0.0.16",
+        "@atproto/lex-schema": "^0.0.19",
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/@atproto/lex-data": {
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.15.tgz",
@@ -347,6 +448,28 @@
       "license": "MIT",
       "dependencies": {
         "@atproto/lex-data": "^0.0.15",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/lex-schema": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-schema/-/lex-schema-0.0.19.tgz",
+      "integrity": "sha512-rEVTnbgYx4FwcvfrfnuACXvBcdkb4wqSOALG9leW302YIPB+HLRSwpBVC0iLun+yozEKg7BJdwiS0bvfje6tcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.15",
+        "@atproto/syntax": "^0.5.4",
+        "@standard-schema/spec": "^1.1.0",
+        "iso-datestring-validator": "^2.2.2",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/lex-schema/node_modules/@atproto/syntax": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.4.tgz",
+      "integrity": "sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==",
+      "license": "MIT",
+      "dependencies": {
         "tslib": "^2.8.1"
       }
     },
@@ -483,6 +606,19 @@
       "integrity": "sha512-8CNmi5DipOLaVeSMPggMe7FCksVag0aO6XZy9WflbduTKM4dFZVCs4686UeMLfGRXX+X966XgwECHoLYrovMMg==",
       "license": "MIT"
     },
+    "node_modules/@atproto/ws-client": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@atproto/ws-client/-/ws-client-0.0.4.tgz",
+      "integrity": "sha512-dox1XIymuC7/ZRhUqKezIGgooZS45C6vHCfu0PnWjfvsLCK2kAlnvX4IBkA/WpcoijDhQ9ejChnFbo/sLmgvAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common": "^0.5.3",
+        "ws": "^8.12.0"
+      },
+      "engines": {
+        "node": ">=18.7.0"
+      }
+    },
     "node_modules/@atproto/xrpc": {
       "version": "0.6.12",
       "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.6.12.tgz",
@@ -491,6 +627,376 @@
       "dependencies": {
         "@atproto/lexicon": "^0.4.10",
         "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/xrpc-server": {
+      "version": "0.10.20",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc-server/-/xrpc-server-0.10.20.tgz",
+      "integrity": "sha512-l8Tog73e49SlNdCDUvTDcTU1lzrfkayKGlYMMlgpoOiVenU0Z4p8vKMqAI9zTqok25k/g7IHg5QdFMTseTUBGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common": "^0.5.16",
+        "@atproto/crypto": "^0.4.5",
+        "@atproto/lex-cbor": "^0.0.16",
+        "@atproto/lex-client": "^0.0.20",
+        "@atproto/lex-data": "^0.0.15",
+        "@atproto/lex-json": "^0.0.16",
+        "@atproto/lex-schema": "^0.0.19",
+        "@atproto/lexicon": "^0.6.2",
+        "@atproto/ws-client": "^0.0.4",
+        "@atproto/xrpc": "^0.7.7",
+        "express": "^4.17.2",
+        "http-errors": "^2.0.0",
+        "mime-types": "^2.1.35",
+        "rate-limiter-flexible": "^2.4.1",
+        "ws": "^8.12.0"
+      },
+      "engines": {
+        "node": ">=18.7.0"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/@atproto/lexicon": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.6.2.tgz",
+      "integrity": "sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.18",
+        "@atproto/syntax": "^0.5.0",
+        "iso-datestring-validator": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/@atproto/syntax": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.4.tgz",
+      "integrity": "sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/@atproto/xrpc": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.7.7.tgz",
+      "integrity": "sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lexicon": "^0.6.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@atproto/xrpc-server/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@atproto/xrpc/node_modules/zod": {
@@ -1456,7 +1962,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/bcrypt": {
@@ -1890,6 +2395,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
     "node_modules/asap": {
@@ -2391,6 +2902,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -2766,6 +3287,15 @@
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
       "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
       "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -3515,7 +4045,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4183,6 +4712,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.2.tgz",
+      "integrity": "sha512-rMATGGOdO1suFyf/mI5LYhts71g1sbdhmd6YvdiXO2gJnd42Tt6QS4JUKJKSWVVkMtBacm6l40FR7Trjo6Iruw==",
+      "license": "ISC"
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
@@ -4888,6 +5423,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/uuid": {
       "version": "13.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@atproto/api": "^0.13.35",
     "@atproto/identity": "^0.4.12",
     "@atproto/oauth-client-node": "^0.3.13",
+    "@atproto/xrpc-server": "^0.10.20",
     "@types/cookie-parser": "^1.4.10",
     "@types/multer": "^2.0.0",
     "bcrypt": "^6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { createStreamRouter } from './routes/stream';
 import { createPermissionsRouter } from './routes/permissions';
 import { createHierarchyRouter } from './routes/hierarchy';
 import { createEventsRouter } from './routes/events';
+import { createXrpcRouter } from './xrpc/server';
 import { createRateLimiter } from './middleware/rateLimit';
 import { csrfProtection } from './middleware/csrf';
 import { logger } from './lib/logger';
@@ -121,6 +122,9 @@ async function start() {
     app.use('/api/v1/stream', createStreamRouter(db, eventStreamService));
 
     app.use('/api/v1/events', createEventsRouter(oauthClient));
+
+    // XRPC endpoints (ATProto-style RPC)
+    app.use('/xrpc', createXrpcRouter(db));
 
     // Error handling
     app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ async function start() {
     // Apply global middleware
     const rateLimiter = createRateLimiter(db);
     app.use('/api/', rateLimiter);
+    app.use('/xrpc/', rateLimiter);
     app.use(csrfProtection);
 
     // Auth routes (OAuth)

--- a/src/xrpc/communities.ts
+++ b/src/xrpc/communities.ts
@@ -1,0 +1,389 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+import type { Request } from 'express';
+import type { Database } from '../db';
+import type { XrpcHandler } from './server';
+import { XrpcError } from './server';
+import type { AuthenticatedRequest } from '../middleware/auth';
+import { createCommunityAgent } from '../services/atproto';
+import { createAuditLogService } from '../services/auditLog';
+import { checkAppVisibility, seedCollectionPermissions } from '../services/permissions';
+import { isAdminInList, normalizeAdmins } from '../lib/adminUtils';
+import { encodeCursor, decodeCursor } from '../lib/pagination';
+import { logger } from '../lib/logger';
+import { logWarning } from '../lib/errors';
+
+export function registerCommunityHandlers(handlers: Map<string, XrpcHandler>, db: Kysely<Database>) {
+  const auditLog = createAuditLogService(db);
+
+  handlers.set('community.opensocial.getCommunity', {
+    type: 'query',
+    handler: async (params, req) => {
+      const communityDid = params.did as string;
+      const userDid = params.userDid as string | undefined;
+
+      if (!communityDid) {
+        throw new XrpcError(400, 'InvalidRequest', 'did is required');
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const appId = (req as AuthenticatedRequest).app_data?.app_id;
+      if (appId) {
+        const visibility = await checkAppVisibility(db, community.did, appId);
+        if (!visibility.allowed) {
+          throw new XrpcError(403, 'PermissionDenied', visibility.reason);
+        }
+      }
+
+      let profile: any = {};
+      let admins: any[] = [];
+      let isAdmin = false;
+      let memberCount = 0;
+
+      try {
+        const agent = await createCommunityAgent(db, communityDid);
+
+        try {
+          const profileRes = await agent.api.com.atproto.repo.getRecord({
+            repo: communityDid,
+            collection: 'community.opensocial.profile',
+            rkey: 'self',
+          });
+          profile = profileRes.data.value as any;
+        } catch (e) {
+          logWarning('Failed to fetch community profile', { error: e, communityDid });
+        }
+
+        try {
+          const adminsRes = await agent.api.com.atproto.repo.getRecord({
+            repo: communityDid,
+            collection: 'community.opensocial.admins',
+            rkey: 'self',
+          });
+          admins = (adminsRes.data.value as any)?.admins || [];
+          if (userDid) {
+            isAdmin = isAdminInList(userDid, admins);
+          }
+        } catch (e) {
+          logWarning('Failed to fetch community admins', { error: e, communityDid, userDid });
+        }
+
+        try {
+          let count = 0;
+          let memberCursor: string | undefined;
+          do {
+            const membersRes = await agent.api.com.atproto.repo.listRecords({
+              repo: communityDid,
+              collection: 'community.opensocial.membershipProof',
+              limit: 100,
+              cursor: memberCursor,
+            });
+            count += membersRes.data.records.length;
+            memberCursor = membersRes.data.cursor;
+          } while (memberCursor);
+          memberCount = count;
+        } catch (e) {
+          logWarning('Failed to count community members', { error: e, communityDid });
+        }
+      } catch (e) {
+        logWarning('Failed to create community agent', { error: e, communityDid });
+      }
+
+      return {
+        community: {
+          did: community.did,
+          handle: community.handle,
+          displayName: profile.displayName || community.display_name,
+          description: profile.description || '',
+          guidelines: profile.guidelines || '',
+          type: profile.type || 'open',
+          avatar: profile.avatar || null,
+          banner: profile.banner || null,
+          admins: normalizeAdmins(admins).map((a) => a.did),
+          createdAt: community.created_at,
+          memberCount,
+        },
+        isAdmin,
+      };
+    },
+  });
+
+  handlers.set('community.opensocial.searchCommunities', {
+    type: 'query',
+    handler: async (params, req) => {
+      const query = params.query as string | undefined;
+      const userDid = params.userDid as string | undefined;
+      const limit = params.limit ? parseInt(params.limit as string, 10) : 25;
+      const cursor = params.cursor as string | undefined;
+      const offset = cursor ? decodeCursor(cursor) : 0;
+
+      const trimmedQuery = query?.trim();
+      if (trimmedQuery && trimmedQuery.length > 0 && trimmedQuery.length < 3) {
+        throw new XrpcError(400, 'QueryTooShort', 'Search query must be at least 3 characters');
+      }
+
+      let dbQuery = db.selectFrom('communities').selectAll();
+
+      if (trimmedQuery && trimmedQuery.length >= 3) {
+        dbQuery = dbQuery.where((eb) =>
+          eb.or([
+            eb(sql`similarity(handle, ${trimmedQuery})`, '>', sql`0.15`),
+            eb(sql`similarity(display_name, ${trimmedQuery})`, '>', sql`0.15`),
+            sql<boolean>`handle ILIKE ${'%' + trimmedQuery + '%'}`,
+            sql<boolean>`display_name ILIKE ${'%' + trimmedQuery + '%'}`,
+          ])
+        );
+      }
+
+      const allCommunities = await dbQuery
+        .orderBy(
+          trimmedQuery && trimmedQuery.length >= 3
+            ? sql`GREATEST(similarity(handle, ${trimmedQuery}), similarity(display_name, ${trimmedQuery}))`
+            : sql`COALESCE(member_count, 0)`,
+          'desc'
+        )
+        .offset(offset)
+        .limit(limit + 1)
+        .execute();
+
+      const hasMore = allCommunities.length > limit;
+      const page = hasMore ? allCommunities.slice(0, limit) : allCommunities;
+
+      const appId = (req as AuthenticatedRequest).app_data?.app_id;
+      const enrichedUnfiltered = await Promise.all(
+        page.map(async (community) => {
+          if (appId) {
+            const visibility = await checkAppVisibility(db, community.did, appId);
+            if (!visibility.allowed) return null;
+          }
+
+          let isAdmin = false;
+          let type = 'open';
+          let memberCount = community.member_count || 0;
+
+          try {
+            const agent = await createCommunityAgent(db, community.did);
+
+            try {
+              const profileRes = await agent.api.com.atproto.repo.getRecord({
+                repo: community.did,
+                collection: 'community.opensocial.profile',
+                rkey: 'self',
+              });
+              type = (profileRes.data.value as any)?.type || 'open';
+            } catch (e) {
+              logWarning('Failed to fetch community profile', { error: e, communityDid: community.did });
+            }
+
+            if (userDid) {
+              try {
+                const adminsRes = await agent.api.com.atproto.repo.getRecord({
+                  repo: community.did,
+                  collection: 'community.opensocial.admins',
+                  rkey: 'self',
+                });
+                const admins = (adminsRes.data.value as any)?.admins || [];
+                isAdmin = isAdminInList(userDid, admins);
+              } catch (e) {
+                logWarning('Failed to fetch community admins', { error: e, communityDid: community.did });
+              }
+            }
+          } catch (e) {
+            logWarning('Failed to create community agent for enrichment', { error: e, communityDid: community.did });
+          }
+
+          return {
+            did: community.did,
+            handle: community.handle,
+            displayName: community.display_name,
+            type,
+            isAdmin,
+            memberCount,
+          };
+        })
+      );
+
+      const communities = enrichedUnfiltered.filter(Boolean);
+
+      return {
+        communities,
+        cursor: hasMore ? encodeCursor(offset + limit) : undefined,
+      };
+    },
+  });
+
+  handlers.set('community.opensocial.getPermissions', {
+    type: 'query',
+    handler: async (params, req) => {
+      const communityDid = params.communityDid as string;
+      const userDid = params.userDid as string | undefined;
+
+      if (!communityDid) {
+        throw new XrpcError(400, 'InvalidRequest', 'communityDid is required');
+      }
+
+      const appId = (req as AuthenticatedRequest).app_data?.app_id;
+      if (!appId) {
+        throw new XrpcError(401, 'InvalidRequest', 'App identification required');
+      }
+
+      const visibility = await checkAppVisibility(db, communityDid, appId);
+      if (!visibility.allowed) {
+        throw new XrpcError(403, 'PermissionDenied', visibility.reason);
+      }
+
+      // Collection permissions
+      let permRows = await db
+        .selectFrom('community_app_collection_permissions')
+        .selectAll()
+        .where('community_did', '=', communityDid)
+        .where('app_id', '=', appId)
+        .orderBy('collection', 'asc')
+        .execute();
+
+      let permissions;
+      if (permRows.length > 0) {
+        permissions = permRows.map((r) => ({
+          collection: r.collection,
+          canCreate: r.can_create,
+          canRead: r.can_read,
+          canUpdate: r.can_update,
+          canDelete: r.can_delete,
+        }));
+      } else {
+        const defaultRows = await db
+          .selectFrom('app_default_permissions')
+          .selectAll()
+          .where('app_id', '=', appId)
+          .orderBy('collection', 'asc')
+          .execute();
+
+        permissions = defaultRows.map((r) => ({
+          collection: r.collection,
+          canCreate: r.default_can_create,
+          canRead: r.default_can_read,
+          canUpdate: r.default_can_update,
+          canDelete: r.default_can_delete,
+        }));
+      }
+
+      // User roles
+      let userRoles: string[] = [];
+      if (userDid) {
+        try {
+          const agent = await createCommunityAgent(db, communityDid);
+
+          let isMember = false;
+          let cursor: string | undefined;
+          do {
+            const membersRes = await agent.api.com.atproto.repo.listRecords({
+              repo: communityDid,
+              collection: 'community.opensocial.membershipProof',
+              limit: 100,
+              cursor,
+            });
+            isMember = membersRes.data.records.some(
+              (r: any) => r.value.memberDid === userDid,
+            );
+            cursor = membersRes.data.cursor;
+          } while (cursor && !isMember);
+
+          if (isMember) userRoles.push('member');
+
+          try {
+            const adminsRes = await agent.api.com.atproto.repo.getRecord({
+              repo: communityDid,
+              collection: 'community.opensocial.admins',
+              rkey: 'self',
+            });
+            const admins = (adminsRes.data.value as any)?.admins || [];
+            if (isAdminInList(userDid, admins)) {
+              userRoles.push('admin');
+            }
+          } catch (e) {
+            logWarning('Failed to check admin status', { error: e, communityDid, userDid });
+          }
+        } catch (e) {
+          logger.warn({ error: e, communityDid, userDid }, 'Failed to resolve user roles from PDS');
+        }
+
+        const customRoles = await db
+          .selectFrom('community_member_roles')
+          .select('role_name')
+          .where('community_did', '=', communityDid)
+          .where('member_did', '=', userDid)
+          .execute();
+        for (const r of customRoles) {
+          if (!userRoles.includes(r.role_name)) {
+            userRoles.push(r.role_name);
+          }
+        }
+      }
+
+      return { permissions, userRoles };
+    },
+  });
+
+  handlers.set('community.opensocial.deleteCommunity', {
+    type: 'procedure',
+    handler: async (input, req) => {
+      const { communityDid, adminDid } = input;
+      if (!communityDid || !adminDid) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid and adminDid are required');
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      try {
+        const agent = await createCommunityAgent(db, communityDid);
+        const adminsRes = await agent.api.com.atproto.repo.getRecord({
+          repo: communityDid,
+          collection: 'community.opensocial.admins',
+          rkey: 'self',
+        });
+        const admins = (adminsRes.data.value as any)?.admins || [];
+        if (!isAdminInList(adminDid, admins)) {
+          throw new XrpcError(403, 'PermissionDenied', 'Not an admin of this community');
+        }
+        if (normalizeAdmins(admins).length > 1) {
+          throw new XrpcError(400, 'MultipleAdmins', 'Community must have only one admin to be deleted. Remove other admins first.');
+        }
+      } catch (e) {
+        if (e instanceof XrpcError) throw e;
+        throw new XrpcError(500, 'InternalServerError', 'Failed to verify admin status');
+      }
+
+      await db.deleteFrom('communities').where('did', '=', communityDid).execute();
+      await db.deleteFrom('pending_members').where('community_did', '=', communityDid).execute();
+      await db.deleteFrom('community_settings').where('community_did', '=', communityDid).execute();
+      await db.deleteFrom('community_app_visibility').where('community_did', '=', communityDid).execute();
+      await db.deleteFrom('community_app_collection_permissions').where('community_did', '=', communityDid).execute();
+      await db.deleteFrom('community_roles').where('community_did', '=', communityDid).execute();
+      await db.deleteFrom('community_member_roles').where('community_did', '=', communityDid).execute();
+
+      await auditLog.log({
+        communityDid,
+        adminDid,
+        action: 'community.deleted',
+      });
+
+      return {};
+    },
+  });
+}

--- a/src/xrpc/members.ts
+++ b/src/xrpc/members.ts
@@ -1,0 +1,583 @@
+import type { Kysely } from 'kysely';
+import type { Request } from 'express';
+import type { Database } from '../db';
+import type { XrpcHandler } from './server';
+import { XrpcError } from './server';
+import { createCommunityAgent } from '../services/atproto';
+import { createAuditLogService } from '../services/auditLog';
+import { createWebhookService } from '../services/webhook';
+import { isAdminInList, getOriginalAdminDid, normalizeAdmins } from '../lib/adminUtils';
+import { encodeCursor, decodeCursor } from '../lib/pagination';
+import { logger } from '../lib/logger';
+import { logWarning } from '../lib/errors';
+
+/**
+ * Resolve a Bluesky profile to get handle, display name, and avatar.
+ */
+async function resolveProfile(did: string): Promise<{ handle: string | null; displayName: string | null; avatar: string | null }> {
+  try {
+    const res = await fetch(`https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(did)}`);
+    if (res.ok) {
+      const data = await res.json() as any;
+      return { handle: data.handle || null, displayName: data.displayName || null, avatar: data.avatar || null };
+    }
+  } catch {}
+  return { handle: null, displayName: null, avatar: null };
+}
+
+async function getCommunityType(agent: any, communityDid: string): Promise<string> {
+  try {
+    const profileRes = await agent.api.com.atproto.repo.getRecord({
+      repo: communityDid,
+      collection: 'community.opensocial.profile',
+      rkey: 'self',
+    });
+    return (profileRes.data.value as any)?.type || 'open';
+  } catch {
+    return 'open';
+  }
+}
+
+export function registerMemberHandlers(handlers: Map<string, XrpcHandler>, db: Kysely<Database>) {
+  const auditLog = createAuditLogService(db);
+  const webhooks = createWebhookService(db);
+
+  handlers.set('community.opensocial.joinCommunity', {
+    type: 'procedure',
+    handler: async (input) => {
+      const { communityDid, userDid, membershipCid } = input;
+      if (!communityDid || !userDid) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid and userDid are required');
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const communityAgent = await createCommunityAgent(db, communityDid);
+
+      // Check if already a member
+      let cursor: string | undefined;
+      let alreadyMember = false;
+      do {
+        const response = await communityAgent.api.com.atproto.repo.listRecords({
+          repo: communityDid,
+          collection: 'community.opensocial.membershipProof',
+          limit: 100,
+          cursor,
+        });
+        alreadyMember = response.data.records.some(
+          (r: any) => r.value.memberDid === userDid
+        );
+        cursor = response.data.cursor;
+      } while (cursor && !alreadyMember);
+
+      if (alreadyMember) {
+        throw new XrpcError(409, 'AlreadyMember', 'Already a member of this community');
+      }
+
+      const communityType = await getCommunityType(communityAgent, communityDid);
+
+      if (communityType === 'admin-approved') {
+        const existing = await db
+          .selectFrom('pending_members')
+          .selectAll()
+          .where('community_did', '=', communityDid)
+          .where('user_did', '=', userDid)
+          .where('status', '=', 'pending')
+          .executeTakeFirst();
+
+        if (existing) {
+          throw new XrpcError(409, 'AlreadyPending', 'Join request already pending');
+        }
+
+        await db
+          .insertInto('pending_members')
+          .values({
+            community_did: communityDid,
+            user_did: userDid,
+            status: 'pending',
+          })
+          .execute();
+
+        return {
+          status: 'pending',
+          message: 'Join request submitted. An admin must approve your request.',
+        };
+      }
+
+      // Open community — create membershipProof immediately
+      await communityAgent.api.com.atproto.repo.createRecord({
+        repo: communityDid,
+        collection: 'community.opensocial.membershipProof',
+        record: {
+          $type: 'community.opensocial.membershipProof',
+          memberDid: userDid,
+          cid: membershipCid || '',
+          confirmedAt: new Date().toISOString(),
+        },
+      });
+
+      await webhooks.dispatch('member.joined', communityDid, {
+        communityDid, memberDid: userDid,
+      });
+
+      return {
+        status: 'joined',
+        message: 'Successfully joined the community',
+        membership: {
+          communityDid,
+          memberDid: userDid,
+          joinedAt: new Date().toISOString(),
+        },
+      };
+    },
+  });
+
+  handlers.set('community.opensocial.leaveCommunity', {
+    type: 'procedure',
+    handler: async (input) => {
+      const { communityDid, userDid } = input;
+      if (!communityDid || !userDid) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid and userDid are required');
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const communityAgent = await createCommunityAgent(db, communityDid);
+
+      // Check if user is the original admin
+      try {
+        const adminsRes = await communityAgent.api.com.atproto.repo.getRecord({
+          repo: communityDid,
+          collection: 'community.opensocial.admins',
+          rkey: 'self',
+        });
+        const admins = (adminsRes.data.value as any)?.admins || [];
+        const originalAdmin = getOriginalAdminDid(admins);
+        if (userDid === originalAdmin) {
+          throw new XrpcError(403, 'CannotLeaveAsAdmin', 'The primary admin cannot leave. Transfer admin role first.');
+        }
+
+        if (isAdminInList(userDid, admins)) {
+          const updatedAdmins = normalizeAdmins(admins).filter(a => a.did !== userDid);
+          await communityAgent.api.com.atproto.repo.putRecord({
+            repo: communityDid,
+            collection: 'community.opensocial.admins',
+            rkey: 'self',
+            record: {
+              $type: 'community.opensocial.admins',
+              admins: updatedAdmins,
+            },
+          });
+        }
+      } catch (e) {
+        if (e instanceof XrpcError) throw e;
+        logWarning('Failed to check admin status when leaving', { error: e, communityDid, userDid });
+      }
+
+      // Find and delete the membershipProof
+      let memberCursor: string | undefined;
+      let proofRecord: any = null;
+      do {
+        const response = await communityAgent.api.com.atproto.repo.listRecords({
+          repo: communityDid,
+          collection: 'community.opensocial.membershipProof',
+          limit: 100,
+          cursor: memberCursor,
+        });
+        proofRecord = response.data.records.find(
+          (r: any) => r.value.memberDid === userDid
+        );
+        memberCursor = response.data.cursor;
+      } while (memberCursor && !proofRecord);
+
+      if (!proofRecord) {
+        throw new XrpcError(404, 'NotMember', 'Not a member of this community');
+      }
+
+      const rkey = proofRecord.uri.split('/').pop()!;
+      await communityAgent.api.com.atproto.repo.deleteRecord({
+        repo: communityDid,
+        collection: 'community.opensocial.membershipProof',
+        rkey,
+      });
+
+      await webhooks.dispatch('member.left', communityDid, {
+        communityDid, memberDid: userDid,
+      });
+
+      return {};
+    },
+  });
+
+  handlers.set('community.opensocial.getMembers', {
+    type: 'query',
+    handler: async (params) => {
+      const communityDid = params.communityDid as string;
+      const userDid = params.userDid as string | undefined;
+      const limit = params.limit ? parseInt(params.limit as string, 10) : 50;
+      const cursor = params.cursor as string | undefined;
+      const offset = cursor ? decodeCursor(cursor) : 0;
+
+      if (!communityDid) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid is required');
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const communityAgent = await createCommunityAgent(db, communityDid);
+
+      const maxFetch = Math.min(offset + limit * 3, 1000);
+      let atCursor: string | undefined;
+      const allProofs: any[] = [];
+      do {
+        const response = await communityAgent.api.com.atproto.repo.listRecords({
+          repo: communityDid,
+          collection: 'community.opensocial.membershipProof',
+          limit: 100,
+          cursor: atCursor,
+        });
+        allProofs.push(...response.data.records);
+        atCursor = response.data.cursor;
+        if (allProofs.length >= maxFetch) break;
+      } while (atCursor);
+
+      // Get admins list
+      let admins: any[] = [];
+      try {
+        const adminsRes = await communityAgent.api.com.atproto.repo.getRecord({
+          repo: communityDid,
+          collection: 'community.opensocial.admins',
+          rkey: 'self',
+        });
+        admins = (adminsRes.data.value as any)?.admins || [];
+      } catch (e) {
+        logWarning('Failed to fetch admins list', { error: e, communityDid });
+      }
+
+      let members = allProofs.map((record: any) => {
+        const memberDid = record.value.memberDid || null;
+        return {
+          did: memberDid,
+          confirmedAt: record.value.confirmedAt || null,
+          isAdmin: memberDid ? isAdminInList(memberDid, admins) : false,
+        };
+      });
+
+      const page = members.slice(offset, offset + limit);
+      const hasMore = allProofs.length >= maxFetch || offset + limit < members.length;
+      const total = members.length;
+
+      // Resolve profiles
+      const enriched = await Promise.all(
+        page.map(async (member) => {
+          if (!member.did) return { ...member, handle: null, displayName: null, avatar: null };
+          const profile = await resolveProfile(member.did);
+          return { ...member, ...profile };
+        })
+      );
+
+      return {
+        members: enriched,
+        total,
+        cursor: hasMore ? encodeCursor(offset + limit) : undefined,
+      };
+    },
+  });
+
+  handlers.set('community.opensocial.approveMember', {
+    type: 'procedure',
+    handler: async (input) => {
+      const { communityDid, adminDid, userDid } = input;
+      if (!communityDid || !adminDid || !userDid) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid, adminDid, and userDid are required');
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const communityAgent = await createCommunityAgent(db, communityDid);
+      const adminsRes = await communityAgent.api.com.atproto.repo.getRecord({
+        repo: communityDid,
+        collection: 'community.opensocial.admins',
+        rkey: 'self',
+      });
+      const admins = (adminsRes.data.value as any)?.admins || [];
+      if (!isAdminInList(adminDid, admins)) {
+        throw new XrpcError(403, 'PermissionDenied', 'Not authorized. Must be an admin.');
+      }
+
+      const pending = await db
+        .selectFrom('pending_members')
+        .selectAll()
+        .where('community_did', '=', communityDid)
+        .where('user_did', '=', userDid)
+        .where('status', '=', 'pending')
+        .executeTakeFirst();
+      if (!pending) {
+        throw new XrpcError(404, 'NoPendingRequest', 'No pending join request found for this user');
+      }
+
+      await communityAgent.api.com.atproto.repo.createRecord({
+        repo: communityDid,
+        collection: 'community.opensocial.membershipProof',
+        record: {
+          $type: 'community.opensocial.membershipProof',
+          memberDid: userDid,
+          cid: '',
+          confirmedAt: new Date().toISOString(),
+        },
+      });
+
+      await db
+        .updateTable('pending_members')
+        .set({ status: 'approved', reviewed_by: adminDid, updated_at: new Date() })
+        .where('id', '=', pending.id)
+        .execute();
+
+      await auditLog.log({
+        communityDid,
+        adminDid,
+        action: 'member.approved',
+        targetDid: userDid,
+      });
+
+      await webhooks.dispatch('member.approved', communityDid, {
+        communityDid, memberDid: userDid, approvedBy: adminDid,
+      });
+
+      return {};
+    },
+  });
+
+  handlers.set('community.opensocial.rejectMember', {
+    type: 'procedure',
+    handler: async (input) => {
+      const { communityDid, adminDid, userDid } = input;
+      if (!communityDid || !adminDid || !userDid) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid, adminDid, and userDid are required');
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const communityAgent = await createCommunityAgent(db, communityDid);
+      const adminsRes = await communityAgent.api.com.atproto.repo.getRecord({
+        repo: communityDid,
+        collection: 'community.opensocial.admins',
+        rkey: 'self',
+      });
+      const admins = (adminsRes.data.value as any)?.admins || [];
+      if (!isAdminInList(adminDid, admins)) {
+        throw new XrpcError(403, 'PermissionDenied', 'Not authorized. Must be an admin.');
+      }
+
+      const pending = await db
+        .selectFrom('pending_members')
+        .selectAll()
+        .where('community_did', '=', communityDid)
+        .where('user_did', '=', userDid)
+        .where('status', '=', 'pending')
+        .executeTakeFirst();
+      if (!pending) {
+        throw new XrpcError(404, 'NoPendingRequest', 'No pending join request found for this user');
+      }
+
+      await db
+        .updateTable('pending_members')
+        .set({ status: 'rejected', reviewed_by: adminDid, updated_at: new Date() })
+        .where('id', '=', pending.id)
+        .execute();
+
+      await auditLog.log({
+        communityDid,
+        adminDid,
+        action: 'member.rejected',
+        targetDid: userDid,
+      });
+
+      await webhooks.dispatch('member.rejected', communityDid, {
+        communityDid, memberDid: userDid, rejectedBy: adminDid,
+      });
+
+      return {};
+    },
+  });
+
+  handlers.set('community.opensocial.removeMember', {
+    type: 'procedure',
+    handler: async (input) => {
+      const { communityDid, adminDid, memberDid } = input;
+      if (!communityDid || !adminDid || !memberDid) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid, adminDid, and memberDid are required');
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const communityAgent = await createCommunityAgent(db, communityDid);
+
+      const adminsRes = await communityAgent.api.com.atproto.repo.getRecord({
+        repo: communityDid,
+        collection: 'community.opensocial.admins',
+        rkey: 'self',
+      });
+      const admins = (adminsRes.data.value as any)?.admins || [];
+      if (!isAdminInList(adminDid, admins)) {
+        throw new XrpcError(403, 'PermissionDenied', 'Not authorized. Must be an admin.');
+      }
+
+      const originalAdmin = getOriginalAdminDid(admins);
+      if (memberDid === originalAdmin) {
+        throw new XrpcError(403, 'CannotRemoveAdmin', 'Cannot remove the primary admin.');
+      }
+
+      // Find membershipProof
+      let memberCursor: string | undefined;
+      let proofRecord: any = null;
+      do {
+        const response = await communityAgent.api.com.atproto.repo.listRecords({
+          repo: communityDid,
+          collection: 'community.opensocial.membershipProof',
+          limit: 100,
+          cursor: memberCursor,
+        });
+        proofRecord = response.data.records.find(
+          (r: any) => r.value.memberDid === memberDid
+        );
+        memberCursor = response.data.cursor;
+      } while (memberCursor && !proofRecord);
+
+      if (!proofRecord) {
+        throw new XrpcError(404, 'MemberNotFound', 'Member not found in this community');
+      }
+
+      const rkey = proofRecord.uri.split('/').pop()!;
+      await communityAgent.api.com.atproto.repo.deleteRecord({
+        repo: communityDid,
+        collection: 'community.opensocial.membershipProof',
+        rkey,
+      });
+
+      // Remove from admin list if they were an admin
+      if (isAdminInList(memberDid, admins)) {
+        const updatedAdmins = normalizeAdmins(admins).filter(a => a.did !== memberDid);
+        await communityAgent.api.com.atproto.repo.putRecord({
+          repo: communityDid,
+          collection: 'community.opensocial.admins',
+          rkey: 'self',
+          record: {
+            $type: 'community.opensocial.admins',
+            admins: updatedAdmins,
+          },
+        });
+      }
+
+      await auditLog.log({
+        communityDid,
+        adminDid,
+        action: 'member.removed',
+        targetDid: memberDid,
+      });
+
+      await webhooks.dispatch('member.removed', communityDid, {
+        communityDid, memberDid, removedBy: adminDid,
+      });
+
+      return {};
+    },
+  });
+
+  handlers.set('community.opensocial.getPendingMembers', {
+    type: 'query',
+    handler: async (params) => {
+      const communityDid = params.communityDid as string;
+      const adminDid = params.adminDid as string;
+
+      if (!communityDid || !adminDid) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid and adminDid are required');
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const communityAgent = await createCommunityAgent(db, communityDid);
+      const adminsRes = await communityAgent.api.com.atproto.repo.getRecord({
+        repo: communityDid,
+        collection: 'community.opensocial.admins',
+        rkey: 'self',
+      });
+      const admins = (adminsRes.data.value as any)?.admins || [];
+      if (!isAdminInList(adminDid, admins)) {
+        throw new XrpcError(403, 'PermissionDenied', 'Not authorized. Must be an admin.');
+      }
+
+      const pending = await db
+        .selectFrom('pending_members')
+        .selectAll()
+        .where('community_did', '=', communityDid)
+        .where('status', '=', 'pending')
+        .orderBy('created_at', 'asc')
+        .execute();
+
+      const members = await Promise.all(
+        pending.map(async (p) => {
+          const profile = await resolveProfile(p.user_did);
+          return {
+            userDid: p.user_did,
+            requestedAt: p.created_at,
+            handle: profile.handle,
+            displayName: profile.displayName,
+            avatar: profile.avatar,
+          };
+        })
+      );
+
+      return { members };
+    },
+  });
+}

--- a/src/xrpc/records.ts
+++ b/src/xrpc/records.ts
@@ -1,0 +1,250 @@
+import type { Kysely } from 'kysely';
+import type { Request } from 'express';
+import type { Database } from '../db';
+import type { XrpcHandler } from './server';
+import { XrpcError } from './server';
+import type { AuthenticatedRequest } from '../middleware/auth';
+import { createCommunityAgent } from '../services/atproto';
+import { createWebhookService } from '../services/webhook';
+import {
+  checkAppVisibility,
+  getRequiredRole,
+  getUserRoles,
+  satisfiesRole,
+  type Operation,
+} from '../services/permissions';
+import { logger } from '../lib/logger';
+
+/**
+ * Shared helper: verify app visibility, resolve user roles, and check
+ * collection-level permission for the given operation.
+ */
+async function enforcePermission(
+  req: Request,
+  db: Kysely<Database>,
+  communityDid: string,
+  userDid: string,
+  collection: string,
+  operation: Operation,
+) {
+  const appId = (req as AuthenticatedRequest).app_data?.app_id;
+  if (!appId) {
+    throw new XrpcError(401, 'PermissionDenied', 'App identification missing');
+  }
+
+  const visibility = await checkAppVisibility(db, communityDid, appId);
+  if (!visibility.allowed) {
+    throw new XrpcError(403, 'PermissionDenied', visibility.reason);
+  }
+
+  const community = await db
+    .selectFrom('communities')
+    .selectAll()
+    .where('did', '=', communityDid)
+    .executeTakeFirst();
+  if (!community) {
+    throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+  }
+
+  const communityAgent = await createCommunityAgent(db, communityDid);
+
+  const requiredRole = await getRequiredRole(db, communityDid, appId, collection, operation);
+  let effectiveRequiredRole: string = requiredRole ?? '';
+  if (!effectiveRequiredRole) {
+    const col = `default_can_${operation}` as const;
+    const appDefault = await db
+      .selectFrom('app_default_permissions')
+      .select(col as any)
+      .where('app_id', '=', appId)
+      .where('collection', '=', collection)
+      .executeTakeFirst();
+    effectiveRequiredRole = appDefault ? (appDefault as any)[col] : 'member';
+  }
+
+  const userRoles = await getUserRoles(db, communityDid, userDid, communityAgent);
+  if (userRoles.length === 0) {
+    throw new XrpcError(403, 'PermissionDenied', 'User is not a member of this community');
+  }
+  if (!satisfiesRole(userRoles, effectiveRequiredRole)) {
+    throw new XrpcError(403, 'PermissionDenied', `Insufficient permissions. Required role: ${effectiveRequiredRole}`);
+  }
+
+  return { communityAgent, userRoles };
+}
+
+export function registerRecordHandlers(handlers: Map<string, XrpcHandler>, db: Kysely<Database>) {
+  const webhooks = createWebhookService(db);
+
+  handlers.set('community.opensocial.createRecord', {
+    type: 'procedure',
+    handler: async (input, req) => {
+      const { communityDid, userDid, collection, record, rkey } = input;
+      if (!communityDid || !userDid || !collection || !record) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid, userDid, collection, and record are required');
+      }
+
+      const { communityAgent } = await enforcePermission(req, db, communityDid, userDid, collection, 'create');
+
+      const response = await communityAgent.api.com.atproto.repo.createRecord({
+        repo: communityDid,
+        collection,
+        rkey,
+        record: { $type: collection, ...record },
+      });
+
+      await webhooks.dispatch('record.created', communityDid, {
+        communityDid, collection, uri: response.data.uri, userDid,
+      });
+
+      return { uri: response.data.uri, cid: response.data.cid };
+    },
+  });
+
+  handlers.set('community.opensocial.putRecord', {
+    type: 'procedure',
+    handler: async (input, req) => {
+      const { communityDid, userDid, collection, rkey, record } = input;
+      if (!communityDid || !userDid || !collection || !rkey || !record) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid, userDid, collection, rkey, and record are required');
+      }
+
+      const { communityAgent } = await enforcePermission(req, db, communityDid, userDid, collection, 'update');
+
+      const response = await communityAgent.api.com.atproto.repo.putRecord({
+        repo: communityDid,
+        collection,
+        rkey,
+        record: { $type: collection, ...record },
+      });
+
+      await webhooks.dispatch('record.updated', communityDid, {
+        communityDid, collection, rkey, uri: response.data.uri, userDid,
+      });
+
+      return { uri: response.data.uri, cid: response.data.cid };
+    },
+  });
+
+  handlers.set('community.opensocial.deleteRecord', {
+    type: 'procedure',
+    handler: async (input, req) => {
+      const { communityDid, userDid, collection, rkey } = input;
+      if (!communityDid || !userDid || !collection || !rkey) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid, userDid, collection, and rkey are required');
+      }
+
+      const { communityAgent } = await enforcePermission(req, db, communityDid, userDid, collection, 'delete');
+
+      await communityAgent.api.com.atproto.repo.deleteRecord({
+        repo: communityDid, collection, rkey,
+      });
+
+      await webhooks.dispatch('record.deleted', communityDid, {
+        communityDid, collection, rkey, userDid,
+      });
+
+      return {};
+    },
+  });
+
+  handlers.set('community.opensocial.listRecords', {
+    type: 'query',
+    handler: async (params, req) => {
+      const { communityDid, collection, userDid } = params;
+      const limit = params.limit ? parseInt(params.limit as string, 10) : 50;
+      const cursor = params.cursor as string | undefined;
+
+      if (!communityDid || !collection) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid and collection are required');
+      }
+
+      const appId = (req as AuthenticatedRequest).app_data?.app_id;
+      if (appId) {
+        const visibility = await checkAppVisibility(db, communityDid, appId);
+        if (!visibility.allowed) {
+          throw new XrpcError(403, 'PermissionDenied', visibility.reason);
+        }
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const communityAgent = await createCommunityAgent(db, communityDid);
+
+      if (userDid && appId) {
+        const requiredRole = await getRequiredRole(db, communityDid, appId, collection, 'read');
+        if (requiredRole) {
+          const userRoles = await getUserRoles(db, communityDid, userDid, communityAgent);
+          if (!satisfiesRole(userRoles, requiredRole)) {
+            throw new XrpcError(403, 'PermissionDenied', `Insufficient permissions to read this collection. Required role: ${requiredRole}`);
+          }
+        }
+      }
+
+      const response = await communityAgent.api.com.atproto.repo.listRecords({
+        repo: communityDid, collection, limit, cursor,
+      });
+
+      return {
+        records: response.data.records,
+        cursor: response.data.cursor || undefined,
+      };
+    },
+  });
+
+  handlers.set('community.opensocial.getRecord', {
+    type: 'query',
+    handler: async (params, req) => {
+      const { communityDid, collection, rkey, userDid } = params;
+
+      if (!communityDid || !collection || !rkey) {
+        throw new XrpcError(400, 'InvalidInput', 'communityDid, collection, and rkey are required');
+      }
+
+      const appId = (req as AuthenticatedRequest).app_data?.app_id;
+      if (appId) {
+        const visibility = await checkAppVisibility(db, communityDid, appId);
+        if (!visibility.allowed) {
+          throw new XrpcError(403, 'PermissionDenied', visibility.reason);
+        }
+      }
+
+      const community = await db
+        .selectFrom('communities')
+        .selectAll()
+        .where('did', '=', communityDid)
+        .executeTakeFirst();
+      if (!community) {
+        throw new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      }
+
+      const communityAgent = await createCommunityAgent(db, communityDid);
+
+      if (userDid && appId) {
+        const requiredRole = await getRequiredRole(db, communityDid, appId, collection, 'read');
+        if (requiredRole) {
+          const userRoles = await getUserRoles(db, communityDid, userDid, communityAgent);
+          if (!satisfiesRole(userRoles, requiredRole)) {
+            throw new XrpcError(403, 'PermissionDenied', `Insufficient permissions to read this collection. Required role: ${requiredRole}`);
+          }
+        }
+      }
+
+      const response = await communityAgent.api.com.atproto.repo.getRecord({
+        repo: communityDid, collection, rkey,
+      });
+
+      return {
+        uri: response.data.uri,
+        cid: response.data.cid,
+        value: response.data.value,
+      };
+    },
+  });
+}

--- a/src/xrpc/server.ts
+++ b/src/xrpc/server.ts
@@ -1,0 +1,134 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import fs from 'fs';
+import path from 'path';
+import type { Kysely } from 'kysely';
+import type { Database } from '../db';
+import { createVerifyApiKey } from '../middleware/auth';
+import { registerRecordHandlers } from './records';
+import { registerCommunityHandlers } from './communities';
+import { registerMemberHandlers } from './members';
+import { logger } from '../lib/logger';
+
+export interface XrpcHandler {
+  type: 'query' | 'procedure';
+  handler: (params: Record<string, any>, req: Request) => Promise<any>;
+}
+
+export class XrpcError extends Error {
+  constructor(
+    public status: number,
+    public errorName: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'XrpcError';
+  }
+}
+
+/**
+ * Load all lexicon JSON files from the lexicons/ directory.
+ */
+function loadLexicons(): Record<string, any> {
+  const lexDir = path.resolve(__dirname, '../../lexicons');
+  const lexicons: Record<string, any> = {};
+  for (const file of fs.readdirSync(lexDir)) {
+    if (!file.endsWith('.json')) continue;
+    const doc = JSON.parse(fs.readFileSync(path.join(lexDir, file), 'utf-8'));
+    if (doc.id && doc.defs?.main) {
+      lexicons[doc.id] = doc.defs.main;
+    }
+  }
+  return lexicons;
+}
+
+/**
+ * Create the XRPC Express router with all handlers registered.
+ */
+export function createXrpcRouter(db: Kysely<Database>): Router {
+  const router = Router();
+  const verifyApiKey = createVerifyApiKey(db);
+  const lexicons = loadLexicons();
+  const handlers = new Map<string, XrpcHandler>();
+
+  // Register all handlers
+  registerRecordHandlers(handlers, db);
+  registerCommunityHandlers(handlers, db);
+  registerMemberHandlers(handlers, db);
+
+  // Apply API key auth to all XRPC routes
+  router.use(verifyApiKey);
+
+  // GET /xrpc/:methodId — XRPC queries
+  router.get('/:methodId', async (req: Request, res: Response, next: NextFunction) => {
+    const methodId = req.params.methodId;
+    const handler = handlers.get(methodId);
+
+    if (!handler) {
+      return res.status(501).json({
+        error: 'MethodNotImplemented',
+        message: `Method not implemented: ${methodId}`,
+      });
+    }
+
+    const lexDef = lexicons[methodId];
+    if (lexDef && lexDef.type !== 'query') {
+      return res.status(400).json({
+        error: 'InvalidRequest',
+        message: `${methodId} is a procedure, use POST`,
+      });
+    }
+
+    try {
+      const result = await handler.handler(req.query as Record<string, any>, req);
+      res.json(result);
+    } catch (err) {
+      handleXrpcError(err, res, methodId);
+    }
+  });
+
+  // POST /xrpc/:methodId — XRPC procedures
+  router.post('/:methodId', async (req: Request, res: Response, next: NextFunction) => {
+    const methodId = req.params.methodId;
+    const handler = handlers.get(methodId);
+
+    if (!handler) {
+      return res.status(501).json({
+        error: 'MethodNotImplemented',
+        message: `Method not implemented: ${methodId}`,
+      });
+    }
+
+    const lexDef = lexicons[methodId];
+    if (lexDef && lexDef.type !== 'procedure') {
+      return res.status(400).json({
+        error: 'InvalidRequest',
+        message: `${methodId} is a query, use GET`,
+      });
+    }
+
+    try {
+      const result = await handler.handler(req.body || {}, req);
+      res.json(result);
+    } catch (err) {
+      handleXrpcError(err, res, methodId);
+    }
+  });
+
+  return router;
+}
+
+function handleXrpcError(err: unknown, res: Response, methodId: string): void {
+  if (err instanceof XrpcError) {
+    res.status(err.status).json({
+      error: err.errorName,
+      message: err.message,
+    });
+    return;
+  }
+
+  logger.error({ error: err, methodId }, 'XRPC handler error');
+  res.status(500).json({
+    error: 'InternalServerError',
+    message: err instanceof Error ? err.message : 'Internal server error',
+  });
+}

--- a/src/xrpc/server.ts
+++ b/src/xrpc/server.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import type { Kysely } from 'kysely';
 import type { Database } from '../db';
 import { createVerifyApiKey } from '../middleware/auth';
+import { createRateLimiter } from '../middleware/rateLimit';
 import { registerRecordHandlers } from './records';
 import { registerCommunityHandlers } from './communities';
 import { registerMemberHandlers } from './members';
@@ -55,7 +56,9 @@ export function createXrpcRouter(db: Kysely<Database>): Router {
   registerCommunityHandlers(handlers, db);
   registerMemberHandlers(handlers, db);
 
-  // Apply API key auth to all XRPC routes
+  // Apply rate limiting and API key auth to all XRPC routes
+  const rateLimiter = createRateLimiter(db);
+  router.use(rateLimiter);
   router.use(verifyApiKey);
 
   // GET /xrpc/:methodId — XRPC queries

--- a/src/xrpc/xrpc.test.ts
+++ b/src/xrpc/xrpc.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Mock all external dependencies before importing the module under test
+vi.mock('../services/atproto', () => ({
+  createCommunityAgent: vi.fn(),
+}));
+
+vi.mock('../services/webhook', () => ({
+  createWebhookService: vi.fn(() => ({
+    dispatch: vi.fn(),
+  })),
+}));
+
+vi.mock('../services/auditLog', () => ({
+  createAuditLogService: vi.fn(() => ({
+    log: vi.fn(),
+  })),
+}));
+
+vi.mock('../services/permissions', () => ({
+  checkAppVisibility: vi.fn(() => ({ allowed: true })),
+  getRequiredRole: vi.fn(() => null),
+  getUserRoles: vi.fn(() => ['member']),
+  satisfiesRole: vi.fn(() => true),
+  seedCollectionPermissions: vi.fn(),
+  ROLE_ADMIN: 'admin',
+  ROLE_MEMBER: 'member',
+}));
+
+vi.mock('../middleware/auth', () => ({
+  createVerifyApiKey: vi.fn(() => {
+    return (req: any, _res: any, next: any) => {
+      req.app_data = {
+        app_id: 'app_test',
+        name: 'Test App',
+        domain: 'test.example.com',
+        creator_did: 'did:plc:creator',
+        api_key: 'test-key',
+        status: 'active',
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      req.auth_method = 'api_key';
+      next();
+    };
+  }),
+}));
+
+vi.mock('../lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+vi.mock('../lib/errors', () => ({
+  logWarning: vi.fn(),
+}));
+
+vi.mock('../lib/adminUtils', () => ({
+  isAdminInList: vi.fn(() => false),
+  normalizeAdmins: vi.fn((admins: any) => admins),
+  getOriginalAdminDid: vi.fn(() => 'did:plc:original'),
+}));
+
+vi.mock('../lib/pagination', () => ({
+  encodeCursor: vi.fn((n: number) => Buffer.from(String(n)).toString('base64')),
+  decodeCursor: vi.fn((c: string) => {
+    try {
+      return parseInt(Buffer.from(c, 'base64').toString('utf-8'), 10) || 0;
+    } catch { return 0; }
+  }),
+}));
+
+// Mock fs.readdirSync and fs.readFileSync for lexicon loading
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      readdirSync: vi.fn(() => [
+        'community.opensocial.listRecords.json',
+        'community.opensocial.createRecord.json',
+        'community.opensocial.getCommunity.json',
+        'community.opensocial.membership.json',
+      ]),
+      readFileSync: vi.fn((filePath: string) => {
+        if (filePath.includes('listRecords')) {
+          return JSON.stringify({
+            lexicon: 1,
+            id: 'community.opensocial.listRecords',
+            defs: { main: { type: 'query' } },
+          });
+        }
+        if (filePath.includes('createRecord')) {
+          return JSON.stringify({
+            lexicon: 1,
+            id: 'community.opensocial.createRecord',
+            defs: { main: { type: 'procedure' } },
+          });
+        }
+        if (filePath.includes('getCommunity')) {
+          return JSON.stringify({
+            lexicon: 1,
+            id: 'community.opensocial.getCommunity',
+            defs: { main: { type: 'query' } },
+          });
+        }
+        if (filePath.includes('membership')) {
+          return JSON.stringify({
+            lexicon: 1,
+            id: 'community.opensocial.membership',
+            defs: { main: { type: 'record' } },
+          });
+        }
+        return '{}';
+      }),
+    },
+  };
+});
+
+import { createXrpcRouter, XrpcError } from './server';
+
+// Create a mock db that returns nothing for most queries
+function createMockDb(): any {
+  const mockChain = {
+    selectAll: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    execute: vi.fn().mockResolvedValue([]),
+    executeTakeFirst: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    selectFrom: vi.fn(() => mockChain),
+    insertInto: vi.fn(() => ({
+      values: vi.fn().mockReturnThis(),
+      onConflict: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue([]),
+    })),
+    updateTable: vi.fn(() => ({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue([]),
+    })),
+    deleteFrom: vi.fn(() => ({
+      where: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue([]),
+    })),
+  };
+}
+
+describe('XRPC Router', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const db = createMockDb();
+    app = express();
+    app.use(express.json());
+    app.use('/xrpc', createXrpcRouter(db));
+  });
+
+  describe('Routing', () => {
+    it('routes GET requests to query handlers', async () => {
+      // community.opensocial.listRecords is registered as a query
+      // It will fail with CommunityNotFound since mock db returns undefined,
+      // but that confirms routing works
+      const res = await request(app)
+        .get('/xrpc/community.opensocial.listRecords')
+        .query({ communityDid: 'did:plc:test', collection: 'test.collection' });
+
+      // Should not be 501 (MethodNotImplemented) — handler is registered
+      expect(res.status).not.toBe(501);
+    });
+
+    it('routes POST requests to procedure handlers', async () => {
+      const res = await request(app)
+        .post('/xrpc/community.opensocial.createRecord')
+        .send({
+          communityDid: 'did:plc:test',
+          userDid: 'did:plc:user',
+          collection: 'test.collection',
+          record: { $type: 'test.collection', text: 'hello' },
+        });
+
+      // Should not be 501 (MethodNotImplemented) — handler is registered
+      expect(res.status).not.toBe(501);
+    });
+
+    it('returns 501 MethodNotImplemented for unknown method IDs', async () => {
+      const getRes = await request(app)
+        .get('/xrpc/community.opensocial.nonExistentMethod');
+      expect(getRes.status).toBe(501);
+      expect(getRes.body.error).toBe('MethodNotImplemented');
+
+      const postRes = await request(app)
+        .post('/xrpc/community.opensocial.nonExistentMethod')
+        .send({});
+      expect(postRes.status).toBe(501);
+      expect(postRes.body.error).toBe('MethodNotImplemented');
+    });
+
+    it('returns 400 InvalidRequest when using wrong HTTP method for a query', async () => {
+      // community.opensocial.listRecords is a query (GET), calling via POST should error
+      const res = await request(app)
+        .post('/xrpc/community.opensocial.listRecords')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('InvalidRequest');
+      expect(res.body.message).toContain('use GET');
+    });
+
+    it('returns 400 InvalidRequest when using wrong HTTP method for a procedure', async () => {
+      // community.opensocial.createRecord is a procedure (POST), calling via GET should error
+      const res = await request(app)
+        .get('/xrpc/community.opensocial.createRecord');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('InvalidRequest');
+      expect(res.body.message).toContain('use POST');
+    });
+  });
+
+  describe('Error formatting', () => {
+    it('formats XRPC errors with error name and message', async () => {
+      const res = await request(app)
+        .get('/xrpc/community.opensocial.listRecords')
+        .query({ communityDid: '', collection: '' });
+
+      // Should get an error response (missing required params)
+      expect(res.body).toHaveProperty('error');
+      expect(res.body).toHaveProperty('message');
+      expect(typeof res.body.error).toBe('string');
+      expect(typeof res.body.message).toBe('string');
+    });
+
+    it('returns proper JSON error for handler exceptions', async () => {
+      const res = await request(app)
+        .get('/xrpc/community.opensocial.getCommunity')
+        .query({ did: 'did:plc:test123' });
+
+      // Handler should run and return CommunityNotFound since db returns undefined
+      expect(res.body.error).toBe('CommunityNotFound');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('XrpcError class', () => {
+    it('creates errors with status, errorName, and message', () => {
+      const err = new XrpcError(404, 'CommunityNotFound', 'Community not found');
+      expect(err.status).toBe(404);
+      expect(err.errorName).toBe('CommunityNotFound');
+      expect(err.message).toBe('Community not found');
+      expect(err.name).toBe('XrpcError');
+    });
+  });
+});


### PR DESCRIPTION
Adds XRPC-compatible endpoints to Open Social for communities, members, and records. This enables Collective Social (and other clients) to interact with Open Social using the AT Protocol XRPC conventions.

## Changes
- XRPC endpoint handlers for community, member, and record operations
- Follows AT Protocol naming conventions

## Related
- Companion PR in collective-social-api: migrates client calls to use these XRPC endpoints