### PR TITLE
Fix membership status always showing pending after approval

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -70,6 +70,7 @@ interface MembershipRecord {
 
 interface MembershipProofRecord {
   cid: string; // CID of the user's membership record
+  memberDid?: string; // DID of the member this proof confirms
 }
 
 // Helper to convert blob reference to CDN URL
@@ -503,8 +504,13 @@ export function createAuthRouter(
               const isConfirmed = proofsResponse.data.records.some(
                 (proof: any) => {
                   const proofValue = proof.value as MembershipProofRecord;
-                  // Check if the proof's CID matches the membership record's CID
-                  return proofValue.cid === membershipRecordResponse.data.cid;
+                  // Match by memberDid (primary) or CID (legacy).
+                  // The approval flow writes cid: "" so CID-only matching
+                  // would never confirm approved members.
+                  return (
+                    proofValue.memberDid === agent.assertDid ||
+                    proofValue.cid === membershipRecordResponse.data.cid
+                  );
                 },
               );
 


### PR DESCRIPTION
## Problem

The `/users/me/memberships` endpoint determines membership confirmation by matching `membershipProof.cid` against the user's membership record CID. However, the approval endpoint (`POST /:did/members/approve`) creates proofs with `cid: ""` (empty string), so approved members are never confirmed and always show as "pending" on the home page.

## Root Cause

- Open join flow: writes `cid: membershipCid` into the proof (works correctly)
- Admin approval flow: writes `cid: ""` into the proof (never matches)

The confirmation check at `src/routes/auth.ts:503` compared `proofValue.cid === membershipRecordResponse.data.cid`, which could never be true for admin-approved members.

## Fix

Match proofs by `memberDid` (which is always set correctly in both flows) in addition to the existing CID check. Also added `memberDid` to the `MembershipProofRecord` type.

## Testing

- Build passes (`npm run build`)
- All tests pass (the one DB-dependent test fails due to no local PostgreSQL, pre-existing)