### PR TITLE
Fix stale memberships by disabling browser cache on user endpoints

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -428,6 +428,8 @@ export function createAuthRouter(
         return res.status(401).json({ error: "Not authenticated" });
       }
 
+      res.setHeader("cache-control", "no-store");
+
       // Fetch user's membership records
       const membershipsResponse = await agent.api.com.atproto.repo.listRecords({
         repo: agent.assertDid,
@@ -562,6 +564,8 @@ export function createAuthRouter(
         return res.status(401).json({ error: "Not authenticated" });
       }
 
+      res.setHeader("cache-control", "no-store");
+
       const userDid = agent.assertDid;
       const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 100);
       const cursor =
@@ -610,6 +614,8 @@ export function createAuthRouter(
       if (!agent) {
         return res.status(401).json({ error: "Not authenticated" });
       }
+
+      res.setHeader("cache-control", "no-store");
 
       const userDid = agent.assertDid;
       const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 100);


### PR DESCRIPTION
## Problem

After joining or leaving a group, the membership list doesn't update until the user logs out and back in.

## Root Cause

`getSessionAgent` (line 178) sets `cache-control: max-age=300` (dev) / `max-age=60` (prod) on **every** response that uses it, including `/users/me/memberships`. The browser caches the response and serves stale data for subsequent requests. Logging out invalidates the cached responses (new session = cache miss).

## Fix

Override with `cache-control: no-store` on mutable user-state endpoints:
- `GET /users/me/memberships`
- `GET /users/me/publications`
- `GET /users/me/events`

This ensures the browser always fetches fresh data for these dynamic endpoints while leaving the session-level caching intact for static resources.

## Related

Follow-up to #82 (membership status fix).