### PR TITLE
Fix community page showing stale membership after leave/join

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Run database migrations
+      run: npm run migrate:up
+      env:
+        DATABASE_URL: postgresql://opensocial_api:test_password@localhost:5432/opensocial_test
+
     - name: Run tests
       run: npm test
       env:

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1044,6 +1044,7 @@ export function createAuthRouter(
   router.get("/communities/:did", async (req: Request, res: Response) => {
     try {
       const agent = await getSessionAgent(req, res, oauthClient);
+      res.setHeader("cache-control", "no-store");
 
       const communityDid = decodeURIComponent(req.params.did);
 
@@ -1205,9 +1206,14 @@ export function createAuthRouter(
       const isMember =
         isAdmin ||
         proofsRecords.some((proof: any) => {
-          // Check if this proof matches the user's membership CID
           if (!userMembership) return false;
-          return proof.value.cid === userMembership.cid;
+          // Match by memberDid (primary) or CID (legacy).
+          // The approval flow writes cid: "" so CID-only matching
+          // would never confirm approved members.
+          return (
+            proof.value.memberDid === agent.assertDid ||
+            proof.value.cid === userMembership.cid
+          );
         });
 
       // Determine membership status: active, pending, or null.

--- a/src/routes/community-membership.test.ts
+++ b/src/routes/community-membership.test.ts
@@ -151,7 +151,6 @@ function setupCommunityInDb(db: Database, communityDid: string) {
       display_name: "Test Community",
       pds_host: "https://pds.example.com",
       app_password: "encrypted:test",
-      creator_did: ADMIN_DID,
     })
     .onConflict((oc) => oc.column("did").doNothing())
     .execute();

--- a/src/routes/community-membership.test.ts
+++ b/src/routes/community-membership.test.ts
@@ -36,34 +36,68 @@ const MEMBERSHIP_CID = "bafyreimembership00000001";
 
 // ── Mock OAuth + agents ──────────────────────────────────────────────────────
 
-const fakeUserAgent = {
-  assertDid: USER_DID,
-  did: USER_DID,
-  signOut: vi.fn(async () => {}),
-  getProfile: vi.fn(async () => ({
-    data: {
-      did: USER_DID,
-      handle: "testuser.bsky.social",
-      displayName: "Test User",
-      avatar: undefined,
-    },
-  })),
-  api: {
-    com: {
-      atproto: {
-        repo: {
-          listRecords: vi.fn(),
-          getRecord: vi.fn(),
-          createRecord: vi.fn(),
+// Use vi.hoisted so the fake agent is available when vi.mock runs (mocks are hoisted)
+const { fakeUserAgent, mockCommunityAgent } = vi.hoisted(() => {
+  const fakeUserAgent = {
+    assertDid: "did:plc:testuser0000000000001",
+    did: "did:plc:testuser0000000000001",
+    signOut: vi.fn(async () => {}),
+    getProfile: vi.fn(async () => ({
+      data: {
+        did: "did:plc:testuser0000000000001",
+        handle: "testuser.bsky.social",
+        displayName: "Test User",
+        avatar: undefined,
+      },
+    })),
+    api: {
+      com: {
+        atproto: {
+          repo: {
+            listRecords: vi.fn(),
+            getRecord: vi.fn(),
+            createRecord: vi.fn(),
+          },
         },
       },
     },
-  },
-};
+  };
+
+  const mockCommunityAgent = {
+    api: {
+      com: {
+        atproto: {
+          repo: {
+            listRecords: vi.fn(),
+            getRecord: vi.fn(),
+            createRecord: vi.fn(),
+          },
+        },
+      },
+    },
+  };
+
+  return { fakeUserAgent, mockCommunityAgent };
+});
+
+// Mock Agent constructor so getSessionAgent returns our fake agent
+vi.mock("@atproto/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@atproto/api")>();
+  function MockAgent() {
+    return fakeUserAgent;
+  }
+  return {
+    ...actual,
+    Agent: MockAgent,
+    BskyAgent: actual.BskyAgent,
+  };
+});
 
 const mockOAuthClient = {
   authorize: vi.fn(),
-  restore: vi.fn(async () => fakeUserAgent),
+  restore: vi.fn(async () => ({
+    getTokenInfo: vi.fn(async () => ({ scope: "atproto transition:generic" })),
+  })),
   revoke: vi.fn(),
   clientMetadata: { client_id: "https://test.opensocial.local" },
 } as any;
@@ -83,20 +117,7 @@ interface Session {
 
 // ── Mock external services ───────────────────────────────────────────────────
 
-// Mock createCommunityAgent so we don't need a real PDS
-const mockCommunityAgent = {
-  api: {
-    com: {
-      atproto: {
-        repo: {
-          listRecords: vi.fn(),
-          getRecord: vi.fn(),
-          createRecord: vi.fn(),
-        },
-      },
-    },
-  },
-};
+// mockCommunityAgent is defined in vi.hoisted() above
 
 vi.mock("../services/atproto", () => ({
   createCommunityAgent: vi.fn(async () => mockCommunityAgent),
@@ -294,8 +315,12 @@ describe("Community membership status", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Re-wire restore to return our fake agent for each test
-    mockOAuthClient.restore.mockResolvedValue(fakeUserAgent);
+    // Re-wire restore to return a fake OAuth session for each test
+    mockOAuthClient.restore.mockResolvedValue({
+      getTokenInfo: vi.fn(async () => ({
+        scope: "atproto transition:generic",
+      })),
+    });
   });
 
   describe("GET /communities/:did - membershipStatus", () => {


### PR DESCRIPTION
## Problem

The community page (`/communities/:did`) shows stale `isMember` status after joining or leaving a group. Users must log out and back in to see the change.

## Root Cause

`GET /communities/:did` calls `getSessionAgent`, which sets `cache-control: max-age=300` (dev) / `max-age=60` (prod) on the response. The browser caches the response including `isMember`, `membershipStatus`, etc., and serves stale data until the TTL expires.

Additionally, this endpoint still used the old CID-only proof matching for `isMember`, which never confirms admin-approved members (same bug fixed in #82 for `/users/me/memberships`).

## Fix

1. Override `cache-control` with `no-store` so the browser always fetches fresh membership state.
2. Apply the `memberDid`-based proof matching (consistent with #82) so admin-approved members are correctly confirmed.

## Related

- #82 (membership status fix for `/users/me/memberships`)
- #83 (cache fix for `/users/me/*` endpoints)

---

## Data Model

```
┌─────────────────────────────────────────────────────────────────────────┐
│ User's PDS (ATProto Repo)                                               │
│                                                                         │
│  community.opensocial.membership                                        │
│  ├── community: DID (which group)                                       │
│  ├── role: "member" | "admin"                                           │
│  └── since: ISO timestamp                                               │
└─────────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────────┐
│ Community's PDS (ATProto Repo)                                          │
│                                                                         │
│  community.opensocial.membershipProof                                   │
│  ├── memberDid: DID (who is confirmed)                                  │
│  ├── cid: string (CID of user's membership record, "" for approvals)    │
│  └── confirmedAt: ISO timestamp                                         │
│                                                                         │
│  community.opensocial.profile                                           │
│  ├── displayName, description, type ("open" | "admin-approved")         │
│  └── avatar, banner, links                                              │
│                                                                         │
│  community.opensocial.admins                                            │
│  └── admins: [{ did }]                                                  │
└─────────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────────┐
│ PostgreSQL (Server DB)                                                   │
│                                                                         │
│  pending_members                                                        │
│  ├── community_did, user_did, status: "pending" | "approved"            │
│                                                                         │
│  communities (credential storage, metadata cache)                       │
│  community_member_roles (RBAC assignments)                              │
└─────────────────────────────────────────────────────────────────────────┘
```

## Sequence: Community Page Load (the flow this PR fixes)

```mermaid
sequenceDiagram
    participant Browser
    participant Server as Open Social Server
    participant UserPDS as User's PDS
    participant CommPDS as Community's PDS

    Browser->>Server: GET /communities/:did (session cookie)
    Server->>Server: getSessionAgent()
    Note over Server: OLD: cache-control: max-age=300
    Note over Server: NEW: cache-control: no-store

    Server->>CommPDS: getRecord(profile)
    Server->>CommPDS: getRecord(admins)
    Server->>CommPDS: listRecords(membershipProof)
    CommPDS-->>Server: all proof records (proofsRecords)

    Server->>UserPDS: listRecords(membership)
    UserPDS-->>Server: userMembership (or null)

    Server->>Server: isMember = isAdmin OR proofsRecords.some(...)
    Note over Server: OLD: proof.value.cid === userMembership.cid
    Note over Server: NEW: proof.value.memberDid === user.did OR cid match

    Server-->>Browser: { isMember, membershipStatus, isAdmin, ... }
```

## Sequence: Join Flow (Open Community)

```mermaid
sequenceDiagram
    participant Browser
    participant Server as Open Social Server
    participant UserPDS as User's PDS
    participant CommPDS as Community's PDS

    Browser->>Server: POST /communities/:did/join
    Server->>CommPDS: getRecord(profile) to check type
    CommPDS-->>Server: type: "open"

    Server->>UserPDS: createRecord(community.opensocial.membership)
    UserPDS-->>Server: { uri, cid: "bafy..." }

    Server->>CommPDS: createRecord(community.opensocial.membershipProof)
    Note right of CommPDS: { memberDid, cid: "bafy...", confirmedAt }
    CommPDS-->>Server: OK

    Server-->>Browser: { status: "joined" }
```

## Sequence: Leave Flow

```mermaid
sequenceDiagram
    participant Browser
    participant Server as Open Social Server
    participant UserPDS as User's PDS
    participant CommPDS as Community's PDS
    participant DB as PostgreSQL

    Browser->>Server: POST /communities/:did/leave
    Server->>CommPDS: listRecords(membershipProof)
    Note right of Server: Find proof where memberDid === user
    CommPDS-->>Server: proof record found

    Server->>UserPDS: listRecords(membership)
    UserPDS-->>Server: membership record(s) found

    Server->>CommPDS: deleteRecord(membershipProof)
    Server->>UserPDS: deleteRecord(membership)
    Server->>DB: DELETE FROM pending_members

    Server-->>Browser: { status: "left" }
    Note over Browser: Next GET /communities/:did fetches fresh (no cache)
```

## Summary of All Fixes in This Series

| Bug | Root Cause | Fix | PR |
|-----|-----------|-----|-----|
| Membership always "pending" after approval | Approval writes `cid: ""`, old check only matched by CID | Match by `memberDid` or CID | #82 |
| Home page stale after join/leave | `getSessionAgent` sets `max-age` on `/users/me/*` | Override with `no-store` | #83 |
| Community page stale after join/leave | Same cache header + CID-only match on `GET /communities/:did` | `no-store` + `memberDid` match | **#84 (this PR)** |
| "View Community" button does nothing | `joinStatus` never cleared in frontend | Reset state + clear URL param | web#39 |


---

## Additional: CI Test Infrastructure Fixes

This PR also fixes pre-existing test failures in `community-membership.test.ts` that were never caught because the CI workflow lacked database setup.

### CI Workflow (`.github/workflows/test.yml`)

Added `npm run migrate:up` step before running tests. The membership tests connect to a real PostgreSQL instance and insert into `communities`/`pending_members` tables, so the schema must exist.

### Test Mocking (`src/routes/community-membership.test.ts`)

Three bugs in the test's mock setup prevented it from ever passing:

1. **`vi.mock` hoisting**: Mock factories are hoisted above variable declarations, so `fakeUserAgent` was `undefined` at mock time. Fixed with `vi.hoisted()` to declare mock objects in the hoisted scope.

2. **Arrow function as constructor**: `vi.fn(() => agent)` doesn't work with `new` (arrow functions can't be constructors). Fixed by using `function MockAgent() { return fakeUserAgent; }`.

3. **Wrong `restore` return shape**: `oauthClient.restore` must return a session-like object (with `getTokenInfo()`), not the agent itself. Fixed to return `{ getTokenInfo: () => ({...}) }`.

Also removed a reference to a non-existent `creator_did` column in the test fixture.