### PR TITLE
Add first-class spaces (permissioned data Phase 1)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -37,6 +37,7 @@ session-authenticated endpoints used by web UIs.
 - [Admins](#admins)
 - [Roles](#roles)
 - [Settings, app visibility & collection permissions](#settings-app-visibility--collection-permissions)
+- [Spaces](#spaces)
 - [Records (generic)](#records-generic)
 - [Announcements (group-only space)](#announcements-group-only-space)
 - [Shared content](#shared-content)
@@ -118,15 +119,15 @@ The [group management methods discussion](https://discourse.atprotocol.community
 proposes a minimal method set apps need to interact with groups, independent
 of how any one service manages them. Here is where Open Social stands on each:
 
-| Proposed method           | Open Social today                                                                                                      | Notes / gaps                                                                                                                                                                                                                |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listGroups`              | `GET /api/v1/communities?userDid=…` · `GET /xrpc/community.opensocial.searchCommunities`                               | Paginated; optional `userDid` filters to that user's groups.                                                                                                                                                                |
-| `isGroupMember`           | `POST /api/v1/communities/:did/membership/check` · `GET /xrpc/community.opensocial.getPermissions`                     | `getPermissions` also returns roles, satisfying the "optional role field" question.                                                                                                                                         |
-| `joinGroup`               | `POST /api/v1/communities/:did/members/join` · `POST /xrpc/community.opensocial.joinCommunity`                         | Honors community type: `open` joins immediately (writes membership proof); `admin-approved` queues a pending request.                                                                                                       |
-| `leaveGroup`              | `POST /api/v1/communities/:did/members/leave` · `POST /xrpc/community.opensocial.leaveCommunity`                       | Primary admin cannot leave without transferring ownership.                                                                                                                                                                  |
-| `listGroupSpaces`         | **Partial** — `GET /api/v1/communities/:did/permissions` enumerates the collections an app can access and at what role | A collection + its permission rule is the current stand-in for a "space." No first-class space object yet; see [PERMISSIONED_DATA.md](PERMISSIONED_DATA.md).                                                                |
-| `invite` / `revokeInvite` | **Gap**                                                                                                                | Closest primitives: admin approval flow (`members/pending`, `approve`, `reject`) and hierarchy invites between communities. No user-level invite objects for invite-only spaces yet.                                        |
-| `createGroupSpace`        | **Gap** (fixed spaces only)                                                                                            | Spaces are currently predefined collections (announcements, shared content) plus whatever collections an app registers permissions for. A generic "create a space with a policy" method is the permissioned-data end state. |
+| Proposed method           | Open Social today                                                                                  | Notes / gaps                                                                                                                                                            |
+| ------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listGroups`              | `GET /api/v1/communities?userDid=…` · `GET /xrpc/community.opensocial.searchCommunities`           | Paginated; optional `userDid` filters to that user's groups.                                                                                                            |
+| `isGroupMember`           | `POST /api/v1/communities/:did/membership/check` · `GET /xrpc/community.opensocial.getPermissions` | `getPermissions` also returns roles, satisfying the "optional role field" question.                                                                                     |
+| `joinGroup`               | `POST /api/v1/communities/:did/members/join` · `POST /xrpc/community.opensocial.joinCommunity`     | Honors community type: `open` joins immediately (writes membership proof); `admin-approved` queues a pending request.                                                   |
+| `leaveGroup`              | `POST /api/v1/communities/:did/members/leave` · `POST /xrpc/community.opensocial.leaveCommunity`   | Primary admin cannot leave without transferring ownership.                                                                                                              |
+| `listGroupSpaces`         | `GET /api/v1/communities/:did/spaces`                                                              | First-class spaces: each has a key, name, policy (read/write access), and its collections. Pass `userDid` to get per-space `canRead`/`canWrite`. See [Spaces](#spaces). |
+| `invite` / `revokeInvite` | `POST /api/v1/communities/:did/spaces/:spaceKey/invites` · `DELETE …/invites/:inviteeDid`          | User-level invites for invite-only spaces (`readAccess: "invite"`). Community-to-community invites remain in the hierarchy flow.                                        |
+| `createGroupSpace`        | `POST /api/v1/communities/:did/spaces`                                                             | Admins create a space by declaring its collections and read/write policy; the definition is mirrored to the community repo as a `community.opensocial.space` record.    |
 
 On the two open questions in the thread:
 
@@ -242,6 +243,38 @@ community defines its access boundaries.
 Resolution order when an app touches a collection: app visibility
 (explicit status → blocklist → community default) → per-community collection
 rule → app's registered defaults → deny/fallback.
+
+## Spaces
+
+Base: `/api/v1/communities/:did/spaces` — API key; mutations are
+admin-gated. A **space** is a named access boundary around one or more
+collections in the community's repo (permissioned data Phase 1 — see
+[PERMISSIONED_DATA.md](PERMISSIONED_DATA.md)). Every community starts with
+an `announcements` space (read = member, write = admin). Space definitions
+are mirrored into the community repo as `community.opensocial.space`
+records so they are discoverable on-protocol; the database registry is
+authoritative for enforcement.
+
+Space policies are enforced as an **additional gate** on the records and
+announcements endpoints: if a collection belongs to a space, the space's
+read/write policy must also be satisfied. A space can only tighten access,
+never loosen it.
+
+| Method & path                           | Description                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /`                                 | List spaces (`listGroupSpaces`). Query: optional `userDid` — adds `canRead`/`canWrite` per space.                                                                                                                                                                                                                                                                                                                               |
+| `POST /`                                | Create a space (`createGroupSpace`). Body: `adminDid`, `spaceKey` (lowercase slug), `name` (1–128), optional `description` (≤512), optional `spaceType` (NSID), `readAccess` (`public` \| `member` \| `admin` \| `invite` \| custom role; default `member`), `writeAccess` (`member` \| `admin` \| custom role; default `admin`), `collections` (1–16 NSIDs). A collection can belong to at most one space (`409` on conflict). |
+| `GET /:spaceKey`                        | Space details. Query: optional `userDid` for access flags.                                                                                                                                                                                                                                                                                                                                                                      |
+| `PUT /:spaceKey`                        | Update `name` / `description` / `readAccess` / `writeAccess` / `collections`. Body includes `adminDid`.                                                                                                                                                                                                                                                                                                                         |
+| `DELETE /:spaceKey`                     | Delete the space (and its invites). Body: `adminDid`. Records in the space's collections are not deleted — they just lose the space gate.                                                                                                                                                                                                                                                                                       |
+| `POST /:spaceKey/invites`               | Invite a user to an invite-only space. Body: `adminDid`, `inviteeDid`.                                                                                                                                                                                                                                                                                                                                                          |
+| `GET /:spaceKey/invites`                | List invites. Query: `adminDid`.                                                                                                                                                                                                                                                                                                                                                                                                |
+| `DELETE /:spaceKey/invites/:inviteeDid` | Revoke an invite. Body: `adminDid`.                                                                                                                                                                                                                                                                                                                                                                                             |
+
+Access semantics: admins always read and write; `readAccess: "invite"`
+admits only explicitly invited DIDs (membership is not sufficient);
+custom-role access admits holders of that role. All space mutations are
+audit-logged (`space.*` actions).
 
 ## Records (generic)
 
@@ -378,13 +411,14 @@ surface, with request/response shapes validated against the lexicon files in
 Record types written by this service (all in the community's repo unless
 noted):
 
-| Lexicon                                                                          | Key    | Purpose                                                                                                |
-| -------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------ |
-| `community.opensocial.profile`                                                   | `self` | Display name, description, avatar/banner, type (`open`/`admin-approved`/`private`), guidelines, links. |
-| `community.opensocial.admins`                                                    | `self` | Ordered admin DIDs; index 0 is the primary admin.                                                      |
-| `community.opensocial.membership`                                                | tid    | Written to the **user's** repo when they join.                                                         |
-| `community.opensocial.membershipProof`                                           | tid    | Community-side confirmation (`memberDid`, `cid` of the user's membership record).                      |
-| `community.opensocial.announcement`                                              | tid    | Group-only announcement (`title`, `text`, `createdBy`, `createdAt`, optional `updatedAt`, `pinned`).   |
-| `community.opensocial.sharedDocument` / `sharedEvent` / `sharedContent` (legacy) | tid    | Content shared into the community.                                                                     |
-| `community.opensocial.hierarchy`                                                 | tid    | Parent/child relationship records.                                                                     |
-| `community.opensocial.authBasic`                                                 | —      | Permission set granting apps write access to the user's `membership` collection.                       |
+| Lexicon                                                                          | Key       | Purpose                                                                                                |
+| -------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| `community.opensocial.profile`                                                   | `self`    | Display name, description, avatar/banner, type (`open`/`admin-approved`/`private`), guidelines, links. |
+| `community.opensocial.admins`                                                    | `self`    | Ordered admin DIDs; index 0 is the primary admin.                                                      |
+| `community.opensocial.membership`                                                | tid       | Written to the **user's** repo when they join.                                                         |
+| `community.opensocial.membershipProof`                                           | tid       | Community-side confirmation (`memberDid`, `cid` of the user's membership record).                      |
+| `community.opensocial.announcement`                                              | tid       | Group-only announcement (`title`, `text`, `createdBy`, `createdAt`, optional `updatedAt`, `pinned`).   |
+| `community.opensocial.sharedDocument` / `sharedEvent` / `sharedContent` (legacy) | tid       | Content shared into the community.                                                                     |
+| `community.opensocial.space`                                                     | space key | Space definition: name, read/write access policy, member collections.                                  |
+| `community.opensocial.hierarchy`                                                 | tid       | Parent/child relationship records.                                                                     |
+| `community.opensocial.authBasic`                                                 | —         | Permission set granting apps write access to the user's `membership` collection.                       |

--- a/docs/PERMISSIONED_DATA.md
+++ b/docs/PERMISSIONED_DATA.md
@@ -57,18 +57,24 @@ Anything learned here (pinning, editing, role delegation to moderators)
 carries forward unchanged, because the permission model is already
 expressed as per-collection, per-operation role rules.
 
-### Phase 1 — first-class spaces
+### Phase 1 — first-class spaces (shipped)
 
-Make spaces explicit objects instead of implicit gated collections:
+Spaces are explicit objects instead of implicit gated collections:
 
-- A `spaces` registry per community: space type (NSID), space key, policy
-  (`public` | `member-list` | `managing-app` | role rule), declared
-  collections.
+- A `community_spaces` registry per community: space key, space type
+  (NSID), read/write access policy (`public` | `member` | `admin` |
+  `invite` | custom role), declared collections. Definitions are mirrored
+  into the community repo as `community.opensocial.space` records for
+  on-protocol discoverability.
 - `listGroupSpaces` and `createGroupSpace` methods (the two gaps identified
   in the [group management methods discussion](https://discourse.atprotocol.community/t/another-follow-up-topic-group-management-methods/941)),
-  plus `invite`/`revokeInvite` objects for invite-only spaces.
-- The announcement space becomes row #1 in the registry rather than a
-  special case.
+  plus `invite`/`revokeInvite` for invite-only spaces — see the
+  [Spaces section of API.md](API.md#spaces).
+- Space policies are enforced as an additional gate on the record-access
+  paths: a space can tighten access beyond the per-app collection
+  permissions (e.g. invite-only reads), never loosen it.
+- The announcement space is row #1 in the registry rather than a special
+  case; every new community gets it by default.
 
 This phase is protocol-independent and immediately useful to client apps.
 

--- a/lexicons/community.opensocial.space.json
+++ b/lexicons/community.opensocial.space.json
@@ -1,0 +1,73 @@
+{
+  "lexicon": 1,
+  "id": "community.opensocial.space",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A space definition: a named access boundary around one or more collections in the community's repo (permissioned data Phase 1). The record key is the space key. The group management service enforces the declared read/write access; this record makes the space discoverable and portable on-protocol.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": [
+          "name",
+          "readAccess",
+          "writeAccess",
+          "collections",
+          "createdBy",
+          "createdAt"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxGraphemes": 128,
+            "description": "Display name of the space"
+          },
+          "description": {
+            "type": "string",
+            "maxGraphemes": 512,
+            "description": "What this space is for"
+          },
+          "spaceType": {
+            "type": "string",
+            "format": "nsid",
+            "description": "NSID describing the space's modality, per the permissioned data proposal (defaults to community.opensocial.space)"
+          },
+          "readAccess": {
+            "type": "string",
+            "maxGraphemes": 100,
+            "description": "Who may read records in this space: 'public', 'member', 'admin', 'invite' (explicit invite list), or a custom role name",
+            "knownValues": ["public", "member", "admin", "invite"]
+          },
+          "writeAccess": {
+            "type": "string",
+            "maxGraphemes": 100,
+            "description": "Minimum role required to write records in this space: 'member', 'admin', or a custom role name",
+            "knownValues": ["member", "admin"]
+          },
+          "collections": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "nsid"
+            },
+            "maxLength": 16,
+            "description": "Collections whose records belong to this space"
+          },
+          "createdBy": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the admin who created the space"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      }
+    }
+  }
+}

--- a/migrations/016_spaces.ts
+++ b/migrations/016_spaces.ts
@@ -1,0 +1,96 @@
+import { Kysely, sql } from "kysely";
+
+/**
+ * Migration: first-class spaces (permissioned data Phase 1).
+ *
+ * A space is a named access boundary around one or more collections in the
+ * community's repo. `community_spaces` is the registry; `space_invites`
+ * holds the explicit invite list for invite-only spaces.
+ *
+ * Backfills an 'announcements' space for every existing community so the
+ * group-only announcement space becomes registry row #1 instead of a
+ * special case.
+ */
+
+const ANNOUNCEMENT_COLLECTION = "community.opensocial.announcement";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable("community_spaces")
+    .addColumn("id", "serial", (c) => c.primaryKey())
+    .addColumn("community_did", "text", (c) => c.notNull())
+    .addColumn("space_key", "text", (c) => c.notNull())
+    .addColumn("name", "text", (c) => c.notNull())
+    .addColumn("description", "text")
+    .addColumn("space_type", "text", (c) =>
+      c.notNull().defaultTo("community.opensocial.space"),
+    )
+    .addColumn("read_access", "text", (c) => c.notNull().defaultTo("member"))
+    .addColumn("write_access", "text", (c) => c.notNull().defaultTo("admin"))
+    .addColumn("collections", "text", (c) => c.notNull().defaultTo("[]"))
+    .addColumn("created_by", "text", (c) => c.notNull())
+    .addColumn("created_at", "timestamptz", (c) =>
+      c.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn("updated_at", "timestamptz", (c) =>
+      c.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("community_spaces_did_key_uniq")
+    .on("community_spaces")
+    .columns(["community_did", "space_key"])
+    .unique()
+    .execute();
+
+  await db.schema
+    .createTable("space_invites")
+    .addColumn("id", "serial", (c) => c.primaryKey())
+    .addColumn("community_did", "text", (c) => c.notNull())
+    .addColumn("space_key", "text", (c) => c.notNull())
+    .addColumn("invitee_did", "text", (c) => c.notNull())
+    .addColumn("invited_by", "text", (c) => c.notNull())
+    .addColumn("created_at", "timestamptz", (c) =>
+      c.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("space_invites_did_key_invitee_uniq")
+    .on("space_invites")
+    .columns(["community_did", "space_key", "invitee_did"])
+    .unique()
+    .execute();
+
+  // Backfill: register the announcement space for existing communities.
+  const communities = await db
+    .selectFrom("communities")
+    .select("did")
+    .execute();
+
+  for (const community of communities) {
+    await db
+      .insertInto("community_spaces")
+      .values({
+        community_did: community.did,
+        space_key: "announcements",
+        name: "Announcements",
+        description: "Group-only announcements from the community admins",
+        space_type: "community.opensocial.space",
+        read_access: "member",
+        write_access: "admin",
+        collections: JSON.stringify([ANNOUNCEMENT_COLLECTION]),
+        created_by: community.did,
+      })
+      .onConflict((oc) =>
+        oc.columns(["community_did", "space_key"]).doNothing(),
+      )
+      .execute();
+  }
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable("space_invites").execute();
+  await db.schema.dropTable("community_spaces").execute();
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,6 @@
-import { Generated, Kysely, PostgresDialect, sql } from 'kysely';
-import { Pool } from 'pg';
-import type { AuthState, AuthSession } from './models/auth';
+import { Generated, Kysely, PostgresDialect, sql } from "kysely";
+import { Pool } from "pg";
+import type { AuthState, AuthSession } from "./models/auth";
 
 export interface Community {
   did: string;
@@ -24,7 +24,7 @@ export interface App {
   domain: string;
   creator_did: string;
   api_key: string;
-  auth_method: 'api_key' | 'http_signature' | 'both';
+  auth_method: "api_key" | "http_signature" | "both";
   cimd_url: string | null;
   created_at: Generated<Date>;
   updated_at: Generated<Date>;
@@ -222,6 +222,40 @@ export interface StreamToken {
   created_at: Generated<Date>;
 }
 
+/**
+ * First-class spaces (permissioned data Phase 1): a named access boundary
+ * around one or more collections in the community's repo. Introduced in
+ * migration 016.
+ */
+export interface CommunitySpace {
+  id: Generated<number>;
+  community_did: string;
+  space_key: string;
+  name: string;
+  description: string | null;
+  /** NSID describing the space's modality. */
+  space_type: string;
+  /** 'public' | 'member' | 'admin' | 'invite' | custom role name */
+  read_access: string;
+  /** 'member' | 'admin' | custom role name */
+  write_access: string;
+  /** JSON array of collection NSIDs belonging to this space. */
+  collections: string;
+  created_by: string;
+  created_at: Generated<Date>;
+  updated_at: Generated<Date>;
+}
+
+/** Explicit invite list for invite-only spaces. */
+export interface SpaceInvite {
+  id: Generated<number>;
+  community_did: string;
+  space_key: string;
+  invitee_did: string;
+  invited_by: string;
+  created_at: Generated<Date>;
+}
+
 // ─── Database type map ───────────────────────────────────────────────
 
 export interface Database {
@@ -243,6 +277,8 @@ export interface Database {
   did_cache: DidCacheEntry;
   event_log: EventLogEntry;
   stream_tokens: StreamToken;
+  community_spaces: CommunitySpace;
+  space_invites: SpaceInvite;
 }
 
 export function createDb(connectionString: string): Kysely<Database> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { createAnnouncementsRouter } from "./routes/announcements";
 import { createWebhookRouter } from "./routes/webhooks";
 import { createStreamRouter } from "./routes/stream";
 import { createPermissionsRouter } from "./routes/permissions";
+import { createSpacesRouter } from "./routes/spaces";
 import { createHierarchyRouter } from "./routes/hierarchy";
 import { createEventsRouter } from "./routes/events";
 import { createXrpcRouter } from "./xrpc/server";
@@ -128,6 +129,7 @@ async function start() {
       createAnnouncementsRouter(oauthClient, db),
     );
     app.use("/api/v1/communities", createPermissionsRouter(db));
+    app.use("/api/v1/communities", createSpacesRouter(db));
     app.use("/api/v1/communities", createHierarchyRouter(db));
     app.use("/api/v1/webhooks", createWebhookRouter(db));
 

--- a/src/routes/announcements.ts
+++ b/src/routes/announcements.ts
@@ -16,6 +16,7 @@ import {
   satisfiesRole,
   type Operation,
 } from "../services/permissions";
+import { enforceSpaceBoundary } from "../services/spaces";
 import { logger } from "../lib/logger";
 import { z } from "zod";
 
@@ -177,6 +178,21 @@ export function createAnnouncementsRouter(
       res.status(403).json({
         error: `Insufficient permissions. Required role: ${effectiveRequiredRole}`,
       });
+      return null;
+    }
+
+    // Space boundary: announcements belong to the 'announcements' space,
+    // so admin-tightened space policies (e.g. invite-only) apply here too.
+    const boundary = await enforceSpaceBoundary(
+      db,
+      communityDid,
+      ANNOUNCEMENT_COLLECTION,
+      operation,
+      userDid,
+      userRoles,
+    );
+    if (!boundary.allowed) {
+      res.status(403).json({ error: boundary.reason });
       return null;
     }
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -29,6 +29,7 @@ import {
 } from "../middleware/auth";
 import { authRateLimiter } from "../middleware/rateLimit";
 import { checkAdmin, seedCollectionPermissions } from "../services/permissions";
+import { ensureDefaultSpaces } from "../services/spaces";
 import { createAuditLogService } from "../services/auditLog";
 import { memberRolesCache } from "../lib/cache";
 import { logger } from "../lib/logger";
@@ -858,6 +859,8 @@ export function createAuthRouter(
             "Failed to enable system app for new community",
           );
         }
+
+        await ensureDefaultSpaces(db, communityDid, agent.assertDid);
 
         return res.json({
           success: true,

--- a/src/routes/communities.ts
+++ b/src/routes/communities.ts
@@ -1,25 +1,32 @@
-import { Router } from 'express';
-import { sql, type Kysely } from 'kysely';
-import type { Database } from '../db';
-import { createVerifyApiKey, type AuthenticatedRequest } from '../middleware/auth';
+import { Router } from "express";
+import { sql, type Kysely } from "kysely";
+import type { Database } from "../db";
+import {
+  createVerifyApiKey,
+  type AuthenticatedRequest,
+} from "../middleware/auth";
 import {
   createCommunityApiKeySchema,
   searchCommunitiesSchema,
   deleteCommunitySchema,
   updateCommunityProfileSchema,
-} from '../validation/schemas';
-import { parsePagination, encodeCursor, decodeCursor } from '../lib/pagination';
-import { isAdminInList, normalizeAdmins } from '../lib/adminUtils';
-import { encrypt } from '../lib/crypto';
-import { createAuditLogService } from '../services/auditLog';
-import { createWebhookService } from '../services/webhook';
-import { createCommunityAgent } from '../services/atproto';
-import { checkAppVisibility, seedCollectionPermissions } from '../services/permissions';
-import { config } from '../config';
-import { logger } from '../lib/logger';
-import { sanitizeUserContent } from '../lib/sanitize';
-import { searchRateLimiter } from '../middleware/rateLimit';
-import { logWarning } from '../lib/errors';
+} from "../validation/schemas";
+import { parsePagination, encodeCursor, decodeCursor } from "../lib/pagination";
+import { isAdminInList, normalizeAdmins } from "../lib/adminUtils";
+import { encrypt } from "../lib/crypto";
+import { createAuditLogService } from "../services/auditLog";
+import { createWebhookService } from "../services/webhook";
+import { createCommunityAgent } from "../services/atproto";
+import {
+  checkAppVisibility,
+  seedCollectionPermissions,
+} from "../services/permissions";
+import { ensureDefaultSpaces } from "../services/spaces";
+import { config } from "../config";
+import { logger } from "../lib/logger";
+import { sanitizeUserContent } from "../lib/sanitize";
+import { searchRateLimiter } from "../middleware/rateLimit";
+import { logWarning } from "../lib/errors";
 
 export function createCommunityRouter(db: Kysely<Database>): Router {
   const router = Router();
@@ -28,24 +35,27 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
   const webhooks = createWebhookService(db);
 
   // Create a community (requires an existing AT Protocol account)
-  router.post('/', verifyApiKey, async (req: AuthenticatedRequest, res) => {
+  router.post("/", verifyApiKey, async (req: AuthenticatedRequest, res) => {
     try {
       const parsed = createCommunityApiKeySchema.safeParse(req.body);
       if (!parsed.success) {
-        return res.status(400).json({ error: 'Invalid input', details: parsed.error.flatten() });
+        return res
+          .status(400)
+          .json({ error: "Invalid input", details: parsed.error.flatten() });
       }
 
-      const { did, appPassword, displayName, creatorDid, description } = parsed.data;
+      const { did, appPassword, displayName, creatorDid, description } =
+        parsed.data;
 
       // Resolve the DID to get its handle
       let handle: string;
-      const pdsHost = config.pdsUrl || 'https://bsky.social';
+      const pdsHost = config.pdsUrl || "https://bsky.social";
       try {
         const profileRes = await fetch(
-          `${pdsHost}/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(did)}`
+          `${pdsHost}/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(did)}`,
         );
         if (profileRes.ok) {
-          const profile = await profileRes.json() as any;
+          const profile = (await profileRes.json()) as any;
           handle = profile.handle || did;
         } else {
           handle = did;
@@ -55,18 +65,23 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
       }
 
       // Verify credentials by logging in with the app password
-      const { BskyAgent } = await import('@atproto/api');
+      const { BskyAgent } = await import("@atproto/api");
       const bskyAgent = new BskyAgent({ service: pdsHost });
       try {
         await bskyAgent.login({ identifier: did, password: appPassword });
       } catch (e) {
-        return res.status(400).json({ error: 'Invalid DID or app password. Could not authenticate with the provided credentials.' });
+        return res
+          .status(400)
+          .json({
+            error:
+              "Invalid DID or app password. Could not authenticate with the provided credentials.",
+          });
       }
 
       // Store in database
       const encryptedPassword = encrypt(appPassword);
       await db
-        .insertInto('communities')
+        .insertInto("communities")
         .values({
           did,
           handle,
@@ -84,37 +99,41 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
         let avatarBlob;
         try {
           const creatorProfileRes = await fetch(
-            `${pdsHost}/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(creatorDid)}`
+            `${pdsHost}/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(creatorDid)}`,
           );
           if (creatorProfileRes.ok) {
-            const creatorProfile = await creatorProfileRes.json() as any;
+            const creatorProfile = (await creatorProfileRes.json()) as any;
             if (creatorProfile.avatar) {
               const blobRes = await fetch(creatorProfile.avatar);
               if (blobRes.ok) {
                 const blobData = new Uint8Array(await blobRes.arrayBuffer());
-                const contentType = blobRes.headers.get('content-type') || 'image/jpeg';
-                const uploadRes = await agent.api.com.atproto.repo.uploadBlob(blobData, {
-                  encoding: contentType,
-                });
+                const contentType =
+                  blobRes.headers.get("content-type") || "image/jpeg";
+                const uploadRes = await agent.api.com.atproto.repo.uploadBlob(
+                  blobData,
+                  {
+                    encoding: contentType,
+                  },
+                );
                 avatarBlob = uploadRes.data.blob;
               }
             }
           }
         } catch (e) {
-          logger.warn({ error: e }, 'Could not copy creator avatar');
+          logger.warn({ error: e }, "Could not copy creator avatar");
         }
 
         // Create profile record
         await agent.api.com.atproto.repo.putRecord({
           repo: did,
-          collection: 'community.opensocial.profile',
-          rkey: 'self',
+          collection: "community.opensocial.profile",
+          rkey: "self",
           record: {
-            $type: 'community.opensocial.profile',
+            $type: "community.opensocial.profile",
             displayName,
-            description: description ? sanitizeUserContent(description) : '',
+            description: description ? sanitizeUserContent(description) : "",
             createdAt: new Date().toISOString(),
-            type: 'open',
+            type: "open",
             ...(avatarBlob ? { avatar: avatarBlob } : {}),
           },
         });
@@ -122,10 +141,10 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
         // Create admins record
         await agent.api.com.atproto.repo.putRecord({
           repo: did,
-          collection: 'community.opensocial.admins',
-          rkey: 'self',
+          collection: "community.opensocial.admins",
+          rkey: "self",
           record: {
-            $type: 'community.opensocial.admins',
+            $type: "community.opensocial.admins",
             admins: [{ did: creatorDid, addedAt: new Date().toISOString() }],
           },
         });
@@ -133,40 +152,47 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
         // Create membership proof for creator
         await agent.api.com.atproto.repo.createRecord({
           repo: did,
-          collection: 'community.opensocial.membershipProof',
+          collection: "community.opensocial.membershipProof",
           record: {
-            $type: 'community.opensocial.membershipProof',
+            $type: "community.opensocial.membershipProof",
             memberDid: creatorDid,
-            cid: '',
+            cid: "",
             confirmedAt: new Date().toISOString(),
           },
         });
       } catch (e) {
-        logger.error({ error: e, did }, 'Failed to create community records');
+        logger.error({ error: e, did }, "Failed to create community records");
       }
 
       // Enable the system app for this community and seed default permissions
       try {
         await db
-          .insertInto('community_app_visibility')
+          .insertInto("community_app_visibility")
           .values({
             community_did: did,
-            app_id: 'app_system',
-            status: 'enabled',
+            app_id: "app_system",
+            status: "enabled",
             created_at: new Date(),
             updated_at: new Date(),
           })
-          .onConflict((oc) => oc.columns(['community_did', 'app_id']).doNothing())
+          .onConflict((oc) =>
+            oc.columns(["community_did", "app_id"]).doNothing(),
+          )
           .execute();
-        await seedCollectionPermissions(db, did, 'app_system');
+        await seedCollectionPermissions(db, did, "app_system");
       } catch (e) {
-        logger.warn({ error: e, did }, 'Failed to enable system app for new community');
+        logger.warn(
+          { error: e, did },
+          "Failed to enable system app for new community",
+        );
       }
+
+      await ensureDefaultSpaces(db, did, creatorDid);
 
       await auditLog.log({
         communityDid: did,
         adminDid: creatorDid,
-        action: 'community.created',
+        action: "community.created",
         metadata: { handle, displayName },
       });
 
@@ -181,195 +207,236 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
         isAdmin: true,
       });
     } catch (error) {
-      logger.error({ error }, 'Create community error');
-      res.status(500).json({ error: 'Failed to create community' });
+      logger.error({ error }, "Create community error");
+      res.status(500).json({ error: "Failed to create community" });
     }
   });
 
   // List / search communities
-  router.get('/', verifyApiKey, searchRateLimiter, async (req: AuthenticatedRequest, res) => {
-    try {
-      const parsed = searchCommunitiesSchema.safeParse(req.query);
-      if (!parsed.success) {
-        return res.status(400).json({ error: 'Invalid query', details: parsed.error.flatten() });
-      }
+  router.get(
+    "/",
+    verifyApiKey,
+    searchRateLimiter,
+    async (req: AuthenticatedRequest, res) => {
+      try {
+        const parsed = searchCommunitiesSchema.safeParse(req.query);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid query", details: parsed.error.flatten() });
+        }
 
-      const { query, userDid, cursor, limit } = parsed.data;
-      const offset = cursor ? decodeCursor(cursor) : 0;
+        const { query, userDid, cursor, limit } = parsed.data;
+        const offset = cursor ? decodeCursor(cursor) : 0;
 
-      let dbQuery = db
-        .selectFrom('communities')
-        .selectAll();
+        let dbQuery = db.selectFrom("communities").selectAll();
 
-      // Search by name or handle — require at least 3 characters
-      const trimmedQuery = query?.trim();
-      if (trimmedQuery && trimmedQuery.length >= 3) {
-        // Fuzzy search: trigram similarity + ILIKE fallback
-        // All user input goes through Kysely parameterised bindings — safe from SQL injection
-        dbQuery = dbQuery.where((eb) =>
-          eb.or([
-            eb(sql`similarity(handle, ${trimmedQuery})`, '>', sql`0.15`),
-            eb(sql`similarity(display_name, ${trimmedQuery})`, '>', sql`0.15`),
-            sql<boolean>`handle ILIKE ${'%' + trimmedQuery + '%'}`,
-            sql<boolean>`display_name ILIKE ${'%' + trimmedQuery + '%'}`,
-          ])
-        );
-      } else if (trimmedQuery && trimmedQuery.length > 0 && trimmedQuery.length < 3) {
-        // Query too short — return empty
-        return res.json({ communities: [], cursor: undefined });
-      }
+        // Search by name or handle — require at least 3 characters
+        const trimmedQuery = query?.trim();
+        if (trimmedQuery && trimmedQuery.length >= 3) {
+          // Fuzzy search: trigram similarity + ILIKE fallback
+          // All user input goes through Kysely parameterised bindings — safe from SQL injection
+          dbQuery = dbQuery.where((eb) =>
+            eb.or([
+              eb(sql`similarity(handle, ${trimmedQuery})`, ">", sql`0.15`),
+              eb(
+                sql`similarity(display_name, ${trimmedQuery})`,
+                ">",
+                sql`0.15`,
+              ),
+              sql<boolean>`handle ILIKE ${"%" + trimmedQuery + "%"}`,
+              sql<boolean>`display_name ILIKE ${"%" + trimmedQuery + "%"}`,
+            ]),
+          );
+        } else if (
+          trimmedQuery &&
+          trimmedQuery.length > 0 &&
+          trimmedQuery.length < 3
+        ) {
+          // Query too short — return empty
+          return res.json({ communities: [], cursor: undefined });
+        }
 
-      const allCommunities = await dbQuery
-        .orderBy(
-          trimmedQuery && trimmedQuery.length >= 3
-            ? sql`GREATEST(similarity(handle, ${trimmedQuery}), similarity(display_name, ${trimmedQuery}))`
-            : sql`COALESCE(member_count, 0)`,
-          'desc'
-        )
-        .offset(offset)
-        .limit(limit + 1)
-        .execute();
+        const allCommunities = await dbQuery
+          .orderBy(
+            trimmedQuery && trimmedQuery.length >= 3
+              ? sql`GREATEST(similarity(handle, ${trimmedQuery}), similarity(display_name, ${trimmedQuery}))`
+              : sql`COALESCE(member_count, 0)`,
+            "desc",
+          )
+          .offset(offset)
+          .limit(limit + 1)
+          .execute();
 
-      const hasMore = allCommunities.length > limit;
-      const page = hasMore ? allCommunities.slice(0, limit) : allCommunities;
+        const hasMore = allCommunities.length > limit;
+        const page = hasMore ? allCommunities.slice(0, limit) : allCommunities;
 
-      // Enrich with profile data, admin status, and member count
-      // Also filter out communities not visible to the requesting app
-      const appId = req.app_data?.app_id;
-      const enrichedUnfiltered = await Promise.all(
-        page.map(async (community) => {
-          // Check app visibility
-          if (appId) {
-            const visibility = await checkAppVisibility(db, community.did, appId);
-            if (!visibility.allowed) return null;
-          }
+        // Enrich with profile data, admin status, and member count
+        // Also filter out communities not visible to the requesting app
+        const appId = req.app_data?.app_id;
+        const enrichedUnfiltered = await Promise.all(
+          page.map(async (community) => {
+            // Check app visibility
+            if (appId) {
+              const visibility = await checkAppVisibility(
+                db,
+                community.did,
+                appId,
+              );
+              if (!visibility.allowed) return null;
+            }
 
-          let isAdmin = false;
-          let type = 'open';
-          let memberCount = 0;
+            let isAdmin = false;
+            let type = "open";
+            let memberCount = 0;
 
-          try {
-            const agent = await createCommunityAgent(db, community.did);
-
-            // Get profile
             try {
-              const profileRes = await agent.api.com.atproto.repo.getRecord({
-                repo: community.did,
-                collection: 'community.opensocial.profile',
-                rkey: 'self',
-              });
-              type = (profileRes.data.value as any)?.type || 'open';
-            } catch (e) {
-              logWarning('Failed to fetch community profile', { error: e, communityDid: community.did });
-            }
+              const agent = await createCommunityAgent(db, community.did);
 
-            // Check admin status
-            if (userDid) {
+              // Get profile
               try {
-                const adminsRes = await agent.api.com.atproto.repo.getRecord({
+                const profileRes = await agent.api.com.atproto.repo.getRecord({
                   repo: community.did,
-                  collection: 'community.opensocial.admins',
-                  rkey: 'self',
+                  collection: "community.opensocial.profile",
+                  rkey: "self",
                 });
-                const admins = (adminsRes.data.value as any)?.admins || [];
-                isAdmin = isAdminInList(userDid, admins);
+                type = (profileRes.data.value as any)?.type || "open";
               } catch (e) {
-                logWarning('Failed to fetch community admins', { error: e, communityDid: community.did, userDid });
-              }
-            }
-
-            // Get member count - use cached value if available and recent
-            if (community.member_count !== null && community.metadata_fetched_at) {
-              const cacheAge = Date.now() - community.metadata_fetched_at.getTime();
-              const cacheValid = cacheAge < 24 * 60 * 60 * 1000; // 24 hours
-              if (cacheValid) {
-                memberCount = community.member_count;
-              }
-            }
-
-            // If not cached or stale, fetch but limit to prevent OOM
-            if (memberCount === 0) {
-              try {
-                const membersRes = await agent.api.com.atproto.repo.listRecords({
-                  repo: community.did,
-                  collection: 'community.opensocial.membershipProof',
-                  limit: 100,
+                logWarning("Failed to fetch community profile", {
+                  error: e,
+                  communityDid: community.did,
                 });
-                // For performance, only count precisely up to 100, estimate beyond
-                let count = membersRes.data.records.length;
-                let memberCursor = membersRes.data.cursor;
-                let iterations = 0;
-                while (memberCursor && iterations < 9) { // Max 1000 members counted precisely
-                  const more = await agent.api.com.atproto.repo.listRecords({
+              }
+
+              // Check admin status
+              if (userDid) {
+                try {
+                  const adminsRes = await agent.api.com.atproto.repo.getRecord({
                     repo: community.did,
-                    collection: 'community.opensocial.membershipProof',
-                    cursor: memberCursor,
-                    limit: 100,
+                    collection: "community.opensocial.admins",
+                    rkey: "self",
                   });
-                  count += more.data.records.length;
-                  memberCursor = more.data.cursor;
-                  iterations++;
+                  const admins = (adminsRes.data.value as any)?.admins || [];
+                  isAdmin = isAdminInList(userDid, admins);
+                } catch (e) {
+                  logWarning("Failed to fetch community admins", {
+                    error: e,
+                    communityDid: community.did,
+                    userDid,
+                  });
                 }
-                // If there are more, we stopped early - indicate 1000+
-                memberCount = memberCursor ? 1000 : count;
-              } catch (e) {
-                logWarning('Failed to count community members', { error: e, communityDid: community.did });
               }
+
+              // Get member count - use cached value if available and recent
+              if (
+                community.member_count !== null &&
+                community.metadata_fetched_at
+              ) {
+                const cacheAge =
+                  Date.now() - community.metadata_fetched_at.getTime();
+                const cacheValid = cacheAge < 24 * 60 * 60 * 1000; // 24 hours
+                if (cacheValid) {
+                  memberCount = community.member_count;
+                }
+              }
+
+              // If not cached or stale, fetch but limit to prevent OOM
+              if (memberCount === 0) {
+                try {
+                  const membersRes =
+                    await agent.api.com.atproto.repo.listRecords({
+                      repo: community.did,
+                      collection: "community.opensocial.membershipProof",
+                      limit: 100,
+                    });
+                  // For performance, only count precisely up to 100, estimate beyond
+                  let count = membersRes.data.records.length;
+                  let memberCursor = membersRes.data.cursor;
+                  let iterations = 0;
+                  while (memberCursor && iterations < 9) {
+                    // Max 1000 members counted precisely
+                    const more = await agent.api.com.atproto.repo.listRecords({
+                      repo: community.did,
+                      collection: "community.opensocial.membershipProof",
+                      cursor: memberCursor,
+                      limit: 100,
+                    });
+                    count += more.data.records.length;
+                    memberCursor = more.data.cursor;
+                    iterations++;
+                  }
+                  // If there are more, we stopped early - indicate 1000+
+                  memberCount = memberCursor ? 1000 : count;
+                } catch (e) {
+                  logWarning("Failed to count community members", {
+                    error: e,
+                    communityDid: community.did,
+                  });
+                }
+              }
+            } catch (e) {
+              logWarning("Failed to create community agent for enrichment", {
+                error: e,
+                communityDid: community.did,
+              });
             }
-          } catch (e) {
-            logWarning('Failed to create community agent for enrichment', { error: e, communityDid: community.did });
-          }
 
-          // Update metadata cache (fire-and-forget)
-          db.updateTable('communities')
-            .set({
-              community_type: type,
-              member_count: memberCount,
-              metadata_fetched_at: new Date(),
-            })
-            .where('did', '=', community.did)
-            .execute()
-            .catch((err) => logger.warn({ error: err, communityDid: community.did }, 'Failed to update community metadata cache'));
+            // Update metadata cache (fire-and-forget)
+            db.updateTable("communities")
+              .set({
+                community_type: type,
+                member_count: memberCount,
+                metadata_fetched_at: new Date(),
+              })
+              .where("did", "=", community.did)
+              .execute()
+              .catch((err) =>
+                logger.warn(
+                  { error: err, communityDid: community.did },
+                  "Failed to update community metadata cache",
+                ),
+              );
 
-          return {
-            did: community.did,
-            handle: community.handle,
-            displayName: community.display_name,
-            pdsHost: community.pds_host,
-            createdAt: community.created_at,
-            type,
-            isAdmin,
-            memberCount,
-          };
-        })
-      );
+            return {
+              did: community.did,
+              handle: community.handle,
+              displayName: community.display_name,
+              pdsHost: community.pds_host,
+              createdAt: community.created_at,
+              type,
+              isAdmin,
+              memberCount,
+            };
+          }),
+        );
 
-      const enriched = enrichedUnfiltered.filter(Boolean);
+        const enriched = enrichedUnfiltered.filter(Boolean);
 
-      res.json({
-        communities: enriched,
-        cursor: hasMore ? encodeCursor(offset + limit) : undefined,
-      });
-    } catch (error) {
-      logger.error({ error }, 'List communities error');
-      res.status(500).json({ error: 'Failed to list communities' });
-    }
-  });
+        res.json({
+          communities: enriched,
+          cursor: hasMore ? encodeCursor(offset + limit) : undefined,
+        });
+      } catch (error) {
+        logger.error({ error }, "List communities error");
+        res.status(500).json({ error: "Failed to list communities" });
+      }
+    },
+  );
 
   // Get community details
-  router.get('/:did', verifyApiKey, async (req: AuthenticatedRequest, res) => {
+  router.get("/:did", verifyApiKey, async (req: AuthenticatedRequest, res) => {
     const communityDid = decodeURIComponent(req.params.did);
     try {
       const userDid = req.query.userDid as string | undefined;
 
       const community = await db
-        .selectFrom('communities')
+        .selectFrom("communities")
         .selectAll()
-        .where('did', '=', communityDid)
+        .where("did", "=", communityDid)
         .executeTakeFirst();
 
       if (!community) {
-        return res.status(404).json({ error: 'Community not found' });
+        return res.status(404).json({ error: "Community not found" });
       }
 
       // App visibility gate
@@ -392,26 +459,33 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
         try {
           const profileRes = await agent.api.com.atproto.repo.getRecord({
             repo: communityDid,
-            collection: 'community.opensocial.profile',
-            rkey: 'self',
+            collection: "community.opensocial.profile",
+            rkey: "self",
           });
           profile = profileRes.data.value as any;
         } catch (e) {
-          logWarning('Failed to fetch community profile', { error: e, communityDid });
+          logWarning("Failed to fetch community profile", {
+            error: e,
+            communityDid,
+          });
         }
 
         try {
           const adminsRes = await agent.api.com.atproto.repo.getRecord({
             repo: communityDid,
-            collection: 'community.opensocial.admins',
-            rkey: 'self',
+            collection: "community.opensocial.admins",
+            rkey: "self",
           });
           admins = (adminsRes.data.value as any)?.admins || [];
           if (userDid) {
             isAdmin = isAdminInList(userDid, admins);
           }
         } catch (e) {
-          logWarning('Failed to fetch community admins', { error: e, communityDid, userDid });
+          logWarning("Failed to fetch community admins", {
+            error: e,
+            communityDid,
+            userDid,
+          });
         }
 
         // Count members
@@ -421,7 +495,7 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
           do {
             const membersRes = await agent.api.com.atproto.repo.listRecords({
               repo: communityDid,
-              collection: 'community.opensocial.membershipProof',
+              collection: "community.opensocial.membershipProof",
               limit: 100,
               cursor: memberCursor,
             });
@@ -430,10 +504,16 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
           } while (memberCursor);
           memberCount = count;
         } catch (e) {
-          logWarning('Failed to count community members', { error: e, communityDid });
+          logWarning("Failed to count community members", {
+            error: e,
+            communityDid,
+          });
         }
       } catch (e) {
-        logWarning('Failed to create community agent', { error: e, communityDid });
+        logWarning("Failed to create community agent", {
+          error: e,
+          communityDid,
+        });
       }
 
       res.json({
@@ -442,9 +522,9 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
           handle: community.handle,
           pdsHost: community.pds_host,
           displayName: profile.displayName || community.display_name,
-          description: profile.description || '',
-          guidelines: profile.guidelines || '',
-          type: profile.type || 'open',
+          description: profile.description || "",
+          guidelines: profile.guidelines || "",
+          type: profile.type || "open",
           avatar: profile.avatar || null,
           banner: profile.banner || null,
           admins: normalizeAdmins(admins).map((a) => a.did),
@@ -454,8 +534,8 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
         isAdmin,
       });
     } catch (error) {
-      logger.error({ error, communityDid }, 'Get community error');
-      res.status(500).json({ error: 'Failed to get community' });
+      logger.error({ error, communityDid }, "Get community error");
+      res.status(500).json({ error: "Failed to get community" });
     }
   });
 
@@ -468,186 +548,236 @@ export function createCommunityRouter(db: Kysely<Database>): Router {
    * Query params:
    *   userDid  — optional. If provided, the user's roles are included.
    */
-  router.get('/:did/permissions', verifyApiKey, async (req: AuthenticatedRequest, res) => {
-    const communityDid = decodeURIComponent(req.params.did);
-    try {
-      const userDid = req.query.userDid as string | undefined;
-      const appId = req.app_data?.app_id;
+  router.get(
+    "/:did/permissions",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      try {
+        const userDid = req.query.userDid as string | undefined;
+        const appId = req.app_data?.app_id;
 
-      if (!appId) {
-        return res.status(401).json({ error: 'App identification required' });
-      }
+        if (!appId) {
+          return res.status(401).json({ error: "App identification required" });
+        }
 
-      // 1. App visibility gate
-      const visibility = await checkAppVisibility(db, communityDid, appId);
-      if (!visibility.allowed) {
-        return res.status(403).json({ error: visibility.reason });
-      }
+        // 1. App visibility gate
+        const visibility = await checkAppVisibility(db, communityDid, appId);
+        if (!visibility.allowed) {
+          return res.status(403).json({ error: visibility.reason });
+        }
 
-      // 2. Collection permissions for this app + community
-      //    First try community-level overrides, then fall back to app defaults.
-      let permRows = await db
-        .selectFrom('community_app_collection_permissions')
-        .selectAll()
-        .where('community_did', '=', communityDid)
-        .where('app_id', '=', appId)
-        .orderBy('collection', 'asc')
-        .execute();
-
-      let permissions;
-      if (permRows.length > 0) {
-        permissions = permRows.map((r) => ({
-          collection: r.collection,
-          canCreate: r.can_create,
-          canRead: r.can_read,
-          canUpdate: r.can_update,
-          canDelete: r.can_delete,
-        }));
-      } else {
-        // No community-level overrides — try app defaults
-        const defaultRows = await db
-          .selectFrom('app_default_permissions')
+        // 2. Collection permissions for this app + community
+        //    First try community-level overrides, then fall back to app defaults.
+        let permRows = await db
+          .selectFrom("community_app_collection_permissions")
           .selectAll()
-          .where('app_id', '=', appId)
-          .orderBy('collection', 'asc')
+          .where("community_did", "=", communityDid)
+          .where("app_id", "=", appId)
+          .orderBy("collection", "asc")
           .execute();
 
-        permissions = defaultRows.map((r) => ({
-          collection: r.collection,
-          canCreate: r.default_can_create,
-          canRead: r.default_can_read,
-          canUpdate: r.default_can_update,
-          canDelete: r.default_can_delete,
-        }));
-      }
+        let permissions;
+        if (permRows.length > 0) {
+          permissions = permRows.map((r) => ({
+            collection: r.collection,
+            canCreate: r.can_create,
+            canRead: r.can_read,
+            canUpdate: r.can_update,
+            canDelete: r.can_delete,
+          }));
+        } else {
+          // No community-level overrides — try app defaults
+          const defaultRows = await db
+            .selectFrom("app_default_permissions")
+            .selectAll()
+            .where("app_id", "=", appId)
+            .orderBy("collection", "asc")
+            .execute();
 
-      // 3. User roles (if userDid provided)
-      let userRoles: string[] = [];
-      if (userDid) {
-        // Check admin status from PDS
-        try {
-          const agent = await createCommunityAgent(db, communityDid);
+          permissions = defaultRows.map((r) => ({
+            collection: r.collection,
+            canCreate: r.default_can_create,
+            canRead: r.default_can_read,
+            canUpdate: r.default_can_update,
+            canDelete: r.default_can_delete,
+          }));
+        }
 
-          // Membership
-          let isMember = false;
-          let cursor: string | undefined;
-          do {
-            const membersRes = await agent.api.com.atproto.repo.listRecords({
-              repo: communityDid,
-              collection: 'community.opensocial.membershipProof',
-              limit: 100,
-              cursor,
-            });
-            isMember = membersRes.data.records.some(
-              (r: any) => r.value.memberDid === userDid,
-            );
-            cursor = membersRes.data.cursor;
-          } while (cursor && !isMember);
-
-          if (isMember) userRoles.push('member');
-
-          // Admin
+        // 3. User roles (if userDid provided)
+        let userRoles: string[] = [];
+        if (userDid) {
+          // Check admin status from PDS
           try {
-            const adminsRes = await agent.api.com.atproto.repo.getRecord({
-              repo: communityDid,
-              collection: 'community.opensocial.admins',
-              rkey: 'self',
-            });
-            const admins = (adminsRes.data.value as any)?.admins || [];
-            if (isAdminInList(userDid, admins)) {
-              userRoles.push('admin');
+            const agent = await createCommunityAgent(db, communityDid);
+
+            // Membership
+            let isMember = false;
+            let cursor: string | undefined;
+            do {
+              const membersRes = await agent.api.com.atproto.repo.listRecords({
+                repo: communityDid,
+                collection: "community.opensocial.membershipProof",
+                limit: 100,
+                cursor,
+              });
+              isMember = membersRes.data.records.some(
+                (r: any) => r.value.memberDid === userDid,
+              );
+              cursor = membersRes.data.cursor;
+            } while (cursor && !isMember);
+
+            if (isMember) userRoles.push("member");
+
+            // Admin
+            try {
+              const adminsRes = await agent.api.com.atproto.repo.getRecord({
+                repo: communityDid,
+                collection: "community.opensocial.admins",
+                rkey: "self",
+              });
+              const admins = (adminsRes.data.value as any)?.admins || [];
+              if (isAdminInList(userDid, admins)) {
+                userRoles.push("admin");
+              }
+            } catch (e) {
+              logWarning("Failed to check admin status", {
+                error: e,
+                communityDid,
+                userDid,
+              });
             }
           } catch (e) {
-            logWarning('Failed to check admin status', { error: e, communityDid, userDid });
+            logger.warn(
+              { error: e, communityDid, userDid },
+              "Failed to resolve user roles from PDS",
+            );
           }
-        } catch (e) {
-          logger.warn({ error: e, communityDid, userDid }, 'Failed to resolve user roles from PDS');
+
+          // Custom roles from DB
+          const customRoles = await db
+            .selectFrom("community_member_roles")
+            .select("role_name")
+            .where("community_did", "=", communityDid)
+            .where("member_did", "=", userDid)
+            .execute();
+          for (const r of customRoles) {
+            if (!userRoles.includes(r.role_name)) {
+              userRoles.push(r.role_name);
+            }
+          }
         }
 
-        // Custom roles from DB
-        const customRoles = await db
-          .selectFrom('community_member_roles')
-          .select('role_name')
-          .where('community_did', '=', communityDid)
-          .where('member_did', '=', userDid)
-          .execute();
-        for (const r of customRoles) {
-          if (!userRoles.includes(r.role_name)) {
-            userRoles.push(r.role_name);
-          }
-        }
+        res.json({ permissions, userRoles });
+      } catch (error) {
+        logger.error({ error, communityDid }, "Get permissions error");
+        res.status(500).json({ error: "Failed to get permissions" });
       }
-
-      res.json({ permissions, userRoles });
-    } catch (error) {
-      logger.error({ error, communityDid }, 'Get permissions error');
-      res.status(500).json({ error: 'Failed to get permissions' });
-    }
-  });
+    },
+  );
 
   // Delete community
-  router.delete('/:did', verifyApiKey, async (req: AuthenticatedRequest, res) => {
-    const communityDid = decodeURIComponent(req.params.did);
-    try {
-      const parsed = deleteCommunitySchema.safeParse(req.body);
-      if (!parsed.success) {
-        return res.status(400).json({ error: 'Invalid input', details: parsed.error.flatten() });
-      }
-
-      const { adminDid } = parsed.data;
-
-      const community = await db
-        .selectFrom('communities')
-        .selectAll()
-        .where('did', '=', communityDid)
-        .executeTakeFirst();
-
-      if (!community) {
-        return res.status(404).json({ error: 'Community not found' });
-      }
-
-      // Verify admin status
+  router.delete(
+    "/:did",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
       try {
-        const agent = await createCommunityAgent(db, communityDid);
-        const adminsRes = await agent.api.com.atproto.repo.getRecord({
-          repo: communityDid,
-          collection: 'community.opensocial.admins',
-          rkey: 'self',
+        const parsed = deleteCommunitySchema.safeParse(req.body);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid input", details: parsed.error.flatten() });
+        }
+
+        const { adminDid } = parsed.data;
+
+        const community = await db
+          .selectFrom("communities")
+          .selectAll()
+          .where("did", "=", communityDid)
+          .executeTakeFirst();
+
+        if (!community) {
+          return res.status(404).json({ error: "Community not found" });
+        }
+
+        // Verify admin status
+        try {
+          const agent = await createCommunityAgent(db, communityDid);
+          const adminsRes = await agent.api.com.atproto.repo.getRecord({
+            repo: communityDid,
+            collection: "community.opensocial.admins",
+            rkey: "self",
+          });
+          const admins = (adminsRes.data.value as any)?.admins || [];
+
+          if (!isAdminInList(adminDid, admins)) {
+            return res
+              .status(403)
+              .json({ error: "Not an admin of this community" });
+          }
+
+          if (normalizeAdmins(admins).length > 1) {
+            return res
+              .status(400)
+              .json({
+                error:
+                  "Community must have only one admin to be deleted. Remove other admins first.",
+              });
+          }
+        } catch (e) {
+          logger.error(
+            { error: e, communityDid },
+            "Failed to verify admin status",
+          );
+          return res
+            .status(500)
+            .json({ error: "Failed to verify admin status" });
+        }
+
+        await db
+          .deleteFrom("communities")
+          .where("did", "=", communityDid)
+          .execute();
+        await db
+          .deleteFrom("pending_members")
+          .where("community_did", "=", communityDid)
+          .execute();
+        await db
+          .deleteFrom("community_settings")
+          .where("community_did", "=", communityDid)
+          .execute();
+        await db
+          .deleteFrom("community_app_visibility")
+          .where("community_did", "=", communityDid)
+          .execute();
+        await db
+          .deleteFrom("community_app_collection_permissions")
+          .where("community_did", "=", communityDid)
+          .execute();
+        await db
+          .deleteFrom("community_roles")
+          .where("community_did", "=", communityDid)
+          .execute();
+        await db
+          .deleteFrom("community_member_roles")
+          .where("community_did", "=", communityDid)
+          .execute();
+
+        await auditLog.log({
+          communityDid,
+          adminDid,
+          action: "community.deleted",
         });
-        const admins = (adminsRes.data.value as any)?.admins || [];
 
-        if (!isAdminInList(adminDid, admins)) {
-          return res.status(403).json({ error: 'Not an admin of this community' });
-        }
-
-        if (normalizeAdmins(admins).length > 1) {
-          return res.status(400).json({ error: 'Community must have only one admin to be deleted. Remove other admins first.' });
-        }
-      } catch (e) {
-        logger.error({ error: e, communityDid }, 'Failed to verify admin status');
-        return res.status(500).json({ error: 'Failed to verify admin status' });
+        res.json({ success: true });
+      } catch (error) {
+        logger.error({ error, communityDid }, "Delete community error");
+        res.status(500).json({ error: "Failed to delete community" });
       }
-
-      await db.deleteFrom('communities').where('did', '=', communityDid).execute();
-      await db.deleteFrom('pending_members').where('community_did', '=', communityDid).execute();
-      await db.deleteFrom('community_settings').where('community_did', '=', communityDid).execute();
-      await db.deleteFrom('community_app_visibility').where('community_did', '=', communityDid).execute();
-      await db.deleteFrom('community_app_collection_permissions').where('community_did', '=', communityDid).execute();
-      await db.deleteFrom('community_roles').where('community_did', '=', communityDid).execute();
-      await db.deleteFrom('community_member_roles').where('community_did', '=', communityDid).execute();
-
-      await auditLog.log({
-        communityDid,
-        adminDid,
-        action: 'community.deleted',
-      });
-
-      res.json({ success: true });
-    } catch (error) {
-      logger.error({ error, communityDid }, 'Delete community error');
-      res.status(500).json({ error: 'Failed to delete community' });
-    }
-  });
+    },
+  );
 
   return router;
 }

--- a/src/routes/records.ts
+++ b/src/routes/records.ts
@@ -1,24 +1,28 @@
-import { Router } from 'express';
-import type { Kysely } from 'kysely';
-import type { Database } from '../db';
-import { createVerifyApiKey, type AuthenticatedRequest } from '../middleware/auth';
+import { Router } from "express";
+import type { Kysely } from "kysely";
+import type { Database } from "../db";
+import {
+  createVerifyApiKey,
+  type AuthenticatedRequest,
+} from "../middleware/auth";
 import {
   createRecordSchema,
   updateRecordSchema,
   deleteRecordSchema,
   listRecordsSchema,
   membershipCheckSchema,
-} from '../validation/schemas';
-import { createCommunityAgent } from '../services/atproto';
-import { createWebhookService } from '../services/webhook';
+} from "../validation/schemas";
+import { createCommunityAgent } from "../services/atproto";
+import { createWebhookService } from "../services/webhook";
 import {
   checkAppVisibility,
   getRequiredRole,
   getUserRoles,
   satisfiesRole,
   type Operation,
-} from '../services/permissions';
-import { logger } from '../lib/logger';
+} from "../services/permissions";
+import { enforceSpaceBoundary } from "../services/spaces";
+import { logger } from "../lib/logger";
 
 export function createRecordsRouter(db: Kysely<Database>): Router {
   const router = Router();
@@ -42,7 +46,7 @@ export function createRecordsRouter(db: Kysely<Database>): Router {
   ) {
     const appId = req.app_data?.app_id;
     if (!appId) {
-      res.status(401).json({ error: 'App identification missing' });
+      res.status(401).json({ error: "App identification missing" });
       return null;
     }
 
@@ -55,39 +59,50 @@ export function createRecordsRouter(db: Kysely<Database>): Router {
 
     // 2. Community exists?
     const community = await db
-      .selectFrom('communities')
+      .selectFrom("communities")
       .selectAll()
-      .where('did', '=', communityDid)
+      .where("did", "=", communityDid)
       .executeTakeFirst();
     if (!community) {
-      res.status(404).json({ error: 'Community not found' });
+      res.status(404).json({ error: "Community not found" });
       return null;
     }
 
     const communityAgent = await createCommunityAgent(db, communityDid);
 
     // 3. Collection permission check
-    const requiredRole = await getRequiredRole(db, communityDid, appId, collection, operation);
+    const requiredRole = await getRequiredRole(
+      db,
+      communityDid,
+      appId,
+      collection,
+      operation,
+    );
 
     // If no community-level permission row exists, check app defaults,
     // then fall back to 'member' if neither exists.
-    let effectiveRequiredRole: string = requiredRole ?? '';
+    let effectiveRequiredRole: string = requiredRole ?? "";
     if (!effectiveRequiredRole) {
       const col = `default_can_${operation}` as const;
       const appDefault = await db
-        .selectFrom('app_default_permissions')
+        .selectFrom("app_default_permissions")
         .select(col as any)
-        .where('app_id', '=', appId)
-        .where('collection', '=', collection)
+        .where("app_id", "=", appId)
+        .where("collection", "=", collection)
         .executeTakeFirst();
-      effectiveRequiredRole = appDefault ? (appDefault as any)[col] : 'member';
+      effectiveRequiredRole = appDefault ? (appDefault as any)[col] : "member";
     }
 
     // 4. Resolve user's roles
-    const userRoles = await getUserRoles(db, communityDid, userDid, communityAgent);
+    const userRoles = await getUserRoles(
+      db,
+      communityDid,
+      userDid,
+      communityAgent,
+    );
 
     if (userRoles.length === 0) {
-      res.status(403).json({ error: 'User is not a member of this community' });
+      res.status(403).json({ error: "User is not a member of this community" });
       return null;
     }
 
@@ -95,6 +110,21 @@ export function createRecordsRouter(db: Kysely<Database>): Router {
       res.status(403).json({
         error: `Insufficient permissions. Required role: ${effectiveRequiredRole}`,
       });
+      return null;
+    }
+
+    // 5. Space boundary: if the collection belongs to a space, the space's
+    //    policy must also be satisfied (spaces only tighten access).
+    const boundary = await enforceSpaceBoundary(
+      db,
+      communityDid,
+      collection,
+      operation,
+      userDid,
+      userRoles,
+    );
+    if (!boundary.allowed) {
+      res.status(403).json({ error: boundary.reason });
       return null;
     }
 
@@ -107,51 +137,71 @@ export function createRecordsRouter(db: Kysely<Database>): Router {
    *
    * Body: { userDid, collection, record, rkey? }
    */
-  router.post('/:did/records', verifyApiKey, async (req: AuthenticatedRequest, res) => {
-    const communityDid = decodeURIComponent(req.params.did);
-    let userDid: string | undefined;
-    let collection: string | undefined;
-    try {
-      const parsed = createRecordSchema.safeParse(req.body);
-      if (!parsed.success) {
-        return res.status(400).json({ error: 'Invalid input', details: parsed.error.flatten() });
+  router.post(
+    "/:did/records",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      let userDid: string | undefined;
+      let collection: string | undefined;
+      try {
+        const parsed = createRecordSchema.safeParse(req.body);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid input", details: parsed.error.flatten() });
+        }
+
+        userDid = parsed.data.userDid;
+        collection = parsed.data.collection;
+        const { record, rkey } = parsed.data;
+
+        const result = await enforcePermission(
+          req,
+          res,
+          communityDid,
+          userDid,
+          collection,
+          "create",
+        );
+        if (!result) return;
+
+        const { communityAgent } = result;
+
+        const response = await communityAgent.api.com.atproto.repo.createRecord(
+          {
+            repo: communityDid,
+            collection,
+            rkey,
+            record: {
+              $type: collection,
+              ...record,
+            },
+          },
+        );
+
+        await webhooks.dispatch("record.created", communityDid, {
+          communityDid,
+          collection,
+          uri: response.data.uri,
+          userDid,
+        });
+
+        res.status(201).json({
+          uri: response.data.uri,
+          cid: response.data.cid,
+        });
+      } catch (error: any) {
+        logger.error(
+          { error, communityDid, collection, userDid },
+          "Error creating community record",
+        );
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to create record" });
       }
-
-      userDid = parsed.data.userDid;
-      collection = parsed.data.collection;
-      const { record, rkey } = parsed.data;
-
-      const result = await enforcePermission(req, res, communityDid, userDid, collection, 'create');
-      if (!result) return;
-
-      const { communityAgent } = result;
-
-      const response = await communityAgent.api.com.atproto.repo.createRecord({
-        repo: communityDid,
-        collection,
-        rkey,
-        record: {
-          $type: collection,
-          ...record,
-        },
-      });
-
-      await webhooks.dispatch('record.created', communityDid, {
-        communityDid,
-        collection,
-        uri: response.data.uri,
-        userDid,
-      });
-
-      res.status(201).json({
-        uri: response.data.uri,
-        cid: response.data.cid,
-      });
-    } catch (error: any) {
-      logger.error({ error, communityDid, collection, userDid }, 'Error creating community record');
-      res.status(500).json({ error: error.message || 'Failed to create record' });
-    }
-  });
+    },
+  );
 
   /**
    * PUT /communities/:did/records
@@ -159,52 +209,70 @@ export function createRecordsRouter(db: Kysely<Database>): Router {
    *
    * Body: { userDid, collection, rkey, record }
    */
-  router.put('/:did/records', verifyApiKey, async (req: AuthenticatedRequest, res) => {
-    const communityDid = decodeURIComponent(req.params.did);
-    let userDid: string | undefined;
-    let collection: string | undefined;
-    try {
-      const parsed = updateRecordSchema.safeParse(req.body);
-      if (!parsed.success) {
-        return res.status(400).json({ error: 'Invalid input', details: parsed.error.flatten() });
+  router.put(
+    "/:did/records",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      let userDid: string | undefined;
+      let collection: string | undefined;
+      try {
+        const parsed = updateRecordSchema.safeParse(req.body);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid input", details: parsed.error.flatten() });
+        }
+
+        userDid = parsed.data.userDid;
+        collection = parsed.data.collection;
+        const { rkey, record } = parsed.data;
+
+        const result = await enforcePermission(
+          req,
+          res,
+          communityDid,
+          userDid,
+          collection,
+          "update",
+        );
+        if (!result) return;
+
+        const { communityAgent } = result;
+
+        const response = await communityAgent.api.com.atproto.repo.putRecord({
+          repo: communityDid,
+          collection,
+          rkey,
+          record: {
+            $type: collection,
+            ...record,
+          },
+        });
+
+        await webhooks.dispatch("record.updated", communityDid, {
+          communityDid,
+          collection,
+          rkey,
+          uri: response.data.uri,
+          userDid,
+        });
+
+        res.json({
+          uri: response.data.uri,
+          cid: response.data.cid,
+        });
+      } catch (error: any) {
+        logger.error(
+          { error, communityDid, collection, userDid },
+          "Error updating community record",
+        );
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to update record" });
       }
-
-      userDid = parsed.data.userDid;
-      collection = parsed.data.collection;
-      const { rkey, record } = parsed.data;
-
-      const result = await enforcePermission(req, res, communityDid, userDid, collection, 'update');
-      if (!result) return;
-
-      const { communityAgent } = result;
-
-      const response = await communityAgent.api.com.atproto.repo.putRecord({
-        repo: communityDid,
-        collection,
-        rkey,
-        record: {
-          $type: collection,
-          ...record,
-        },
-      });
-
-      await webhooks.dispatch('record.updated', communityDid, {
-        communityDid,
-        collection,
-        rkey,
-        uri: response.data.uri,
-        userDid,
-      });
-
-      res.json({
-        uri: response.data.uri,
-        cid: response.data.cid,
-      });
-    } catch (error: any) {
-      logger.error({ error, communityDid, collection, userDid }, 'Error updating community record');
-      res.status(500).json({ error: error.message || 'Failed to update record' });
-    }
-  });
+    },
+  );
 
   /**
    * DELETE /communities/:did/records/:collection/:rkey
@@ -212,42 +280,60 @@ export function createRecordsRouter(db: Kysely<Database>): Router {
    *
    * Query: ?userDid=...
    */
-  router.delete('/:did/records/:collection/:rkey', verifyApiKey, async (req: AuthenticatedRequest, res) => {
-    const communityDid = decodeURIComponent(req.params.did);
-    const { collection, rkey } = req.params;
-    let userDid: string | undefined;
-    try {
-      const parsed = deleteRecordSchema.safeParse(req.query);
-      if (!parsed.success) {
-        return res.status(400).json({ error: 'Invalid query', details: parsed.error.flatten() });
+  router.delete(
+    "/:did/records/:collection/:rkey",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      const { collection, rkey } = req.params;
+      let userDid: string | undefined;
+      try {
+        const parsed = deleteRecordSchema.safeParse(req.query);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid query", details: parsed.error.flatten() });
+        }
+
+        userDid = parsed.data.userDid;
+
+        const result = await enforcePermission(
+          req,
+          res,
+          communityDid,
+          userDid,
+          collection,
+          "delete",
+        );
+        if (!result) return;
+
+        const { communityAgent } = result;
+
+        await communityAgent.api.com.atproto.repo.deleteRecord({
+          repo: communityDid,
+          collection,
+          rkey,
+        });
+
+        await webhooks.dispatch("record.deleted", communityDid, {
+          communityDid,
+          collection,
+          rkey,
+          userDid,
+        });
+
+        res.json({ success: true });
+      } catch (error: any) {
+        logger.error(
+          { error, communityDid, collection, userDid },
+          "Error deleting community record",
+        );
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to delete record" });
       }
-
-      userDid = parsed.data.userDid;
-
-      const result = await enforcePermission(req, res, communityDid, userDid, collection, 'delete');
-      if (!result) return;
-
-      const { communityAgent } = result;
-
-      await communityAgent.api.com.atproto.repo.deleteRecord({
-        repo: communityDid,
-        collection,
-        rkey,
-      });
-
-      await webhooks.dispatch('record.deleted', communityDid, {
-        communityDid,
-        collection,
-        rkey,
-        userDid,
-      });
-
-      res.json({ success: true });
-    } catch (error: any) {
-      logger.error({ error, communityDid, collection, userDid }, 'Error deleting community record');
-      res.status(500).json({ error: error.message || 'Failed to delete record' });
-    }
-  });
+    },
+  );
 
   /**
    * GET /communities/:did/records/:collection
@@ -255,125 +341,175 @@ export function createRecordsRouter(db: Kysely<Database>): Router {
    *
    * Now subject to app visibility and read permission checks.
    */
-  router.get('/:did/records/:collection', verifyApiKey, async (req: AuthenticatedRequest, res) => {
-    const communityDid = decodeURIComponent(req.params.did);
-    const collection = req.params.collection;
-    try {
-      const parsed = listRecordsSchema.safeParse(req.query);
-      if (!parsed.success) {
-        return res.status(400).json({ error: 'Invalid query', details: parsed.error.flatten() });
-      }
-
-      const { limit, cursor } = parsed.data;
-      const userDid = req.query.userDid as string | undefined;
-      const appId = req.app_data?.app_id;
-
-      // App visibility gate
-      if (appId) {
-        const visibility = await checkAppVisibility(db, communityDid, appId);
-        if (!visibility.allowed) {
-          return res.status(403).json({ error: visibility.reason });
+  router.get(
+    "/:did/records/:collection",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      const collection = req.params.collection;
+      try {
+        const parsed = listRecordsSchema.safeParse(req.query);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid query", details: parsed.error.flatten() });
         }
-      }
 
-      const community = await db
-        .selectFrom('communities')
-        .selectAll()
-        .where('did', '=', communityDid)
-        .executeTakeFirst();
+        const { limit, cursor } = parsed.data;
+        const userDid = req.query.userDid as string | undefined;
+        const appId = req.app_data?.app_id;
 
-      if (!community) {
-        return res.status(404).json({ error: 'Community not found' });
-      }
-
-      const communityAgent = await createCommunityAgent(db, communityDid);
-
-      // Check read permissions if a userDid is supplied and permission rows exist
-      if (userDid && appId) {
-        const requiredRole = await getRequiredRole(db, communityDid, appId, collection, 'read');
-        if (requiredRole) {
-          const userRoles = await getUserRoles(db, communityDid, userDid, communityAgent);
-          if (!satisfiesRole(userRoles, requiredRole)) {
-            return res.status(403).json({ error: `Insufficient permissions to read this collection. Required role: ${requiredRole}` });
+        // App visibility gate
+        if (appId) {
+          const visibility = await checkAppVisibility(db, communityDid, appId);
+          if (!visibility.allowed) {
+            return res.status(403).json({ error: visibility.reason });
           }
         }
+
+        const community = await db
+          .selectFrom("communities")
+          .selectAll()
+          .where("did", "=", communityDid)
+          .executeTakeFirst();
+
+        if (!community) {
+          return res.status(404).json({ error: "Community not found" });
+        }
+
+        const communityAgent = await createCommunityAgent(db, communityDid);
+
+        // Check read permissions if a userDid is supplied and permission rows exist
+        if (userDid && appId) {
+          const requiredRole = await getRequiredRole(
+            db,
+            communityDid,
+            appId,
+            collection,
+            "read",
+          );
+          if (requiredRole) {
+            const userRoles = await getUserRoles(
+              db,
+              communityDid,
+              userDid,
+              communityAgent,
+            );
+            if (!satisfiesRole(userRoles, requiredRole)) {
+              return res
+                .status(403)
+                .json({
+                  error: `Insufficient permissions to read this collection. Required role: ${requiredRole}`,
+                });
+            }
+          }
+        }
+
+        const response = await communityAgent.api.com.atproto.repo.listRecords({
+          repo: communityDid,
+          collection,
+          limit,
+          cursor,
+        });
+
+        res.json({
+          records: response.data.records,
+          cursor: response.data.cursor || undefined,
+        });
+      } catch (error: any) {
+        logger.error(
+          { error, communityDid, collection },
+          "Error listing community records",
+        );
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to list records" });
       }
-
-      const response = await communityAgent.api.com.atproto.repo.listRecords({
-        repo: communityDid,
-        collection,
-        limit,
-        cursor,
-      });
-
-      res.json({
-        records: response.data.records,
-        cursor: response.data.cursor || undefined,
-      });
-    } catch (error: any) {
-      logger.error({ error, communityDid, collection }, 'Error listing community records');
-      res.status(500).json({ error: error.message || 'Failed to list records' });
-    }
-  });
+    },
+  );
 
   /**
    * GET /communities/:did/records/:collection/:rkey
    * Get a specific record.
    */
-  router.get('/:did/records/:collection/:rkey', verifyApiKey, async (req: AuthenticatedRequest, res) => {
-    const communityDid = decodeURIComponent(req.params.did);
-    const { collection, rkey } = req.params;
-    try {
-      const userDid = req.query.userDid as string | undefined;
-      const appId = req.app_data?.app_id;
+  router.get(
+    "/:did/records/:collection/:rkey",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      const { collection, rkey } = req.params;
+      try {
+        const userDid = req.query.userDid as string | undefined;
+        const appId = req.app_data?.app_id;
 
-      // App visibility gate
-      if (appId) {
-        const visibility = await checkAppVisibility(db, communityDid, appId);
-        if (!visibility.allowed) {
-          return res.status(403).json({ error: visibility.reason });
-        }
-      }
-
-      const community = await db
-        .selectFrom('communities')
-        .selectAll()
-        .where('did', '=', communityDid)
-        .executeTakeFirst();
-
-      if (!community) {
-        return res.status(404).json({ error: 'Community not found' });
-      }
-
-      const communityAgent = await createCommunityAgent(db, communityDid);
-
-      // Check read permissions if a userDid is supplied and permission rows exist
-      if (userDid && appId) {
-        const requiredRole = await getRequiredRole(db, communityDid, appId, collection, 'read');
-        if (requiredRole) {
-          const userRoles = await getUserRoles(db, communityDid, userDid, communityAgent);
-          if (!satisfiesRole(userRoles, requiredRole)) {
-            return res.status(403).json({ error: `Insufficient permissions to read this collection. Required role: ${requiredRole}` });
+        // App visibility gate
+        if (appId) {
+          const visibility = await checkAppVisibility(db, communityDid, appId);
+          if (!visibility.allowed) {
+            return res.status(403).json({ error: visibility.reason });
           }
         }
+
+        const community = await db
+          .selectFrom("communities")
+          .selectAll()
+          .where("did", "=", communityDid)
+          .executeTakeFirst();
+
+        if (!community) {
+          return res.status(404).json({ error: "Community not found" });
+        }
+
+        const communityAgent = await createCommunityAgent(db, communityDid);
+
+        // Check read permissions if a userDid is supplied and permission rows exist
+        if (userDid && appId) {
+          const requiredRole = await getRequiredRole(
+            db,
+            communityDid,
+            appId,
+            collection,
+            "read",
+          );
+          if (requiredRole) {
+            const userRoles = await getUserRoles(
+              db,
+              communityDid,
+              userDid,
+              communityAgent,
+            );
+            if (!satisfiesRole(userRoles, requiredRole)) {
+              return res
+                .status(403)
+                .json({
+                  error: `Insufficient permissions to read this collection. Required role: ${requiredRole}`,
+                });
+            }
+          }
+        }
+
+        const response = await communityAgent.api.com.atproto.repo.getRecord({
+          repo: communityDid,
+          collection,
+          rkey,
+        });
+
+        res.json({
+          uri: response.data.uri,
+          cid: response.data.cid,
+          value: response.data.value,
+        });
+      } catch (error: any) {
+        logger.error(
+          { error, communityDid, collection, rkey },
+          "Error getting community record",
+        );
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to get record" });
       }
-
-      const response = await communityAgent.api.com.atproto.repo.getRecord({
-        repo: communityDid,
-        collection,
-        rkey,
-      });
-
-      res.json({
-        uri: response.data.uri,
-        cid: response.data.cid,
-        value: response.data.value,
-      });
-    } catch (error: any) {
-      logger.error({ error, communityDid, collection, rkey }, 'Error getting community record');
-      res.status(500).json({ error: error.message || 'Failed to get record' });
-    }
-  });
+    },
+  );
 
   return router;
 }

--- a/src/routes/spaces.ts
+++ b/src/routes/spaces.ts
@@ -1,0 +1,639 @@
+/**
+ * Routes for first-class spaces (permissioned data Phase 1).
+ *
+ * Implements the space methods proposed in the group management methods
+ * discussion: listGroupSpaces (GET /:did/spaces), createGroupSpace
+ * (POST /:did/spaces), and invite/revokeInvite for invite-only spaces.
+ *
+ * Mounted under /api/v1/communities and protected by API key auth.
+ * Admin-only operations verify the caller via the AT Proto admins record,
+ * mirroring the permissions router.
+ */
+
+import { Router } from "express";
+import type { Kysely } from "kysely";
+import type { Database } from "../db";
+import {
+  createVerifyApiKey,
+  type AuthenticatedRequest,
+} from "../middleware/auth";
+import {
+  createSpaceSchema,
+  updateSpaceSchema,
+  deleteSpaceSchema,
+  createSpaceInviteSchema,
+  revokeSpaceInviteSchema,
+} from "../validation/schemas";
+import { createCommunityAgent } from "../services/atproto";
+import {
+  checkAdmin,
+  checkAppVisibility,
+  getUserRoles,
+} from "../services/permissions";
+import {
+  SPACE_COLLECTION,
+  canReadSpace,
+  canWriteSpace,
+  getSpace,
+  listSpaces,
+  parseSpaceCollections,
+  type SpaceRow,
+} from "../services/spaces";
+import { createAuditLogService } from "../services/auditLog";
+import { logger } from "../lib/logger";
+
+function serializeSpace(space: SpaceRow) {
+  return {
+    spaceKey: space.space_key,
+    name: space.name,
+    description: space.description ?? undefined,
+    spaceType: space.space_type,
+    readAccess: space.read_access,
+    writeAccess: space.write_access,
+    collections: parseSpaceCollections(space),
+    createdBy: space.created_by,
+    createdAt: space.created_at,
+    updatedAt: space.updated_at,
+  };
+}
+
+export function createSpacesRouter(db: Kysely<Database>): Router {
+  const router = Router();
+  const verifyApiKey = createVerifyApiKey(db);
+  const auditLog = createAuditLogService(db);
+
+  async function requireAdmin(
+    communityDid: string,
+    adminDid: string,
+    res: any,
+  ): Promise<any | null> {
+    const communityAgent = await createCommunityAgent(db, communityDid);
+    const isAdm = await checkAdmin(communityAgent, communityDid, adminDid);
+    if (!isAdm) {
+      res.status(403).json({ error: "Not authorized. Must be an admin." });
+      return null;
+    }
+    return communityAgent;
+  }
+
+  async function requireCommunityAndVisibility(
+    req: AuthenticatedRequest,
+    res: any,
+    communityDid: string,
+  ): Promise<boolean> {
+    const appId = req.app_data?.app_id;
+    if (appId) {
+      const visibility = await checkAppVisibility(db, communityDid, appId);
+      if (!visibility.allowed) {
+        res.status(403).json({ error: visibility.reason });
+        return false;
+      }
+    }
+    const community = await db
+      .selectFrom("communities")
+      .select("did")
+      .where("did", "=", communityDid)
+      .executeTakeFirst();
+    if (!community) {
+      res.status(404).json({ error: "Community not found" });
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Best-effort mirror of the space definition into the community's repo
+   * (collection community.opensocial.space, rkey = spaceKey) so spaces are
+   * discoverable on-protocol. The database row is authoritative for
+   * enforcement, so a failed repo write only logs a warning.
+   */
+  async function mirrorSpaceRecord(communityDid: string, space: SpaceRow) {
+    try {
+      const communityAgent = await createCommunityAgent(db, communityDid);
+      await communityAgent.api.com.atproto.repo.putRecord({
+        repo: communityDid,
+        collection: SPACE_COLLECTION,
+        rkey: space.space_key,
+        record: {
+          $type: SPACE_COLLECTION,
+          name: space.name,
+          ...(space.description ? { description: space.description } : {}),
+          spaceType: space.space_type,
+          readAccess: space.read_access,
+          writeAccess: space.write_access,
+          collections: parseSpaceCollections(space),
+          createdBy: space.created_by,
+          createdAt:
+            space.created_at instanceof Date
+              ? space.created_at.toISOString()
+              : String(space.created_at),
+          updatedAt: new Date().toISOString(),
+        },
+      });
+    } catch (err) {
+      logger.warn(
+        { error: err, communityDid, spaceKey: space.space_key },
+        "Failed to mirror space record to community repo",
+      );
+    }
+  }
+
+  async function deleteSpaceRecord(communityDid: string, spaceKey: string) {
+    try {
+      const communityAgent = await createCommunityAgent(db, communityDid);
+      await communityAgent.api.com.atproto.repo.deleteRecord({
+        repo: communityDid,
+        collection: SPACE_COLLECTION,
+        rkey: spaceKey,
+      });
+    } catch (err) {
+      logger.warn(
+        { error: err, communityDid, spaceKey },
+        "Failed to delete space record from community repo",
+      );
+    }
+  }
+
+  /** Reject collections already claimed by a different space. */
+  async function findCollectionConflict(
+    communityDid: string,
+    collections: string[],
+    excludeSpaceKey?: string,
+  ): Promise<{ collection: string; spaceKey: string } | null> {
+    const spaces = await listSpaces(db, communityDid);
+    for (const space of spaces) {
+      if (excludeSpaceKey && space.space_key === excludeSpaceKey) continue;
+      const owned = parseSpaceCollections(space);
+      const clash = collections.find((c) => owned.includes(c));
+      if (clash) return { collection: clash, spaceKey: space.space_key };
+    }
+    return null;
+  }
+
+  // ─── GET /:did/spaces — listGroupSpaces ───────────────────────────────
+  router.get(
+    "/:did/spaces",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      try {
+        if (!(await requireCommunityAndVisibility(req, res, communityDid)))
+          return;
+
+        const userDid = req.query.userDid as string | undefined;
+        const spaces = await listSpaces(db, communityDid);
+
+        if (!userDid) {
+          return res.json({ spaces: spaces.map(serializeSpace) });
+        }
+
+        const communityAgent = await createCommunityAgent(db, communityDid);
+        const userRoles = await getUserRoles(
+          db,
+          communityDid,
+          userDid,
+          communityAgent,
+        );
+        const withAccess = await Promise.all(
+          spaces.map(async (space) => ({
+            ...serializeSpace(space),
+            canRead: await canReadSpace(db, space, userDid, userRoles),
+            canWrite: canWriteSpace(space, userRoles),
+          })),
+        );
+        res.json({ spaces: withAccess });
+      } catch (error: any) {
+        logger.error({ error, communityDid }, "Error listing spaces");
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to list spaces" });
+      }
+    },
+  );
+
+  // ─── POST /:did/spaces — createGroupSpace ─────────────────────────────
+  router.post(
+    "/:did/spaces",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      try {
+        const parsed = createSpaceSchema.safeParse(req.body);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid input", details: parsed.error.flatten() });
+        }
+        const {
+          adminDid,
+          spaceKey,
+          name,
+          description,
+          spaceType,
+          readAccess,
+          writeAccess,
+          collections,
+        } = parsed.data;
+
+        if (!(await requireCommunityAndVisibility(req, res, communityDid)))
+          return;
+        if (!(await requireAdmin(communityDid, adminDid, res))) return;
+
+        const existing = await getSpace(db, communityDid, spaceKey);
+        if (existing) {
+          return res
+            .status(409)
+            .json({ error: `Space '${spaceKey}' already exists` });
+        }
+
+        const conflict = await findCollectionConflict(
+          communityDid,
+          collections,
+        );
+        if (conflict) {
+          return res.status(409).json({
+            error: `Collection ${conflict.collection} already belongs to space '${conflict.spaceKey}'`,
+          });
+        }
+
+        await db
+          .insertInto("community_spaces")
+          .values({
+            community_did: communityDid,
+            space_key: spaceKey,
+            name,
+            description: description ?? null,
+            space_type: spaceType ?? SPACE_COLLECTION,
+            read_access: readAccess,
+            write_access: writeAccess,
+            collections: JSON.stringify(collections),
+            created_by: adminDid,
+          })
+          .execute();
+
+        const space = (await getSpace(db, communityDid, spaceKey))!;
+        await mirrorSpaceRecord(communityDid, space);
+
+        await auditLog.log({
+          communityDid,
+          adminDid,
+          action: "space.created",
+          metadata: { spaceKey, readAccess, writeAccess, collections },
+        });
+
+        res.status(201).json({ space: serializeSpace(space) });
+      } catch (error: any) {
+        logger.error({ error, communityDid }, "Error creating space");
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to create space" });
+      }
+    },
+  );
+
+  // ─── GET /:did/spaces/:spaceKey ───────────────────────────────────────
+  router.get(
+    "/:did/spaces/:spaceKey",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      const spaceKey = req.params.spaceKey;
+      try {
+        if (!(await requireCommunityAndVisibility(req, res, communityDid)))
+          return;
+
+        const space = await getSpace(db, communityDid, spaceKey);
+        if (!space) {
+          return res.status(404).json({ error: "Space not found" });
+        }
+
+        const userDid = req.query.userDid as string | undefined;
+        if (!userDid) {
+          return res.json({ space: serializeSpace(space) });
+        }
+
+        const communityAgent = await createCommunityAgent(db, communityDid);
+        const userRoles = await getUserRoles(
+          db,
+          communityDid,
+          userDid,
+          communityAgent,
+        );
+        res.json({
+          space: {
+            ...serializeSpace(space),
+            canRead: await canReadSpace(db, space, userDid, userRoles),
+            canWrite: canWriteSpace(space, userRoles),
+          },
+        });
+      } catch (error: any) {
+        logger.error({ error, communityDid, spaceKey }, "Error fetching space");
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to fetch space" });
+      }
+    },
+  );
+
+  // ─── PUT /:did/spaces/:spaceKey ───────────────────────────────────────
+  router.put(
+    "/:did/spaces/:spaceKey",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      const spaceKey = req.params.spaceKey;
+      try {
+        const parsed = updateSpaceSchema.safeParse(req.body);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid input", details: parsed.error.flatten() });
+        }
+        const {
+          adminDid,
+          name,
+          description,
+          readAccess,
+          writeAccess,
+          collections,
+        } = parsed.data;
+
+        if (!(await requireCommunityAndVisibility(req, res, communityDid)))
+          return;
+        if (!(await requireAdmin(communityDid, adminDid, res))) return;
+
+        const space = await getSpace(db, communityDid, spaceKey);
+        if (!space) {
+          return res.status(404).json({ error: "Space not found" });
+        }
+
+        if (collections) {
+          const conflict = await findCollectionConflict(
+            communityDid,
+            collections,
+            spaceKey,
+          );
+          if (conflict) {
+            return res.status(409).json({
+              error: `Collection ${conflict.collection} already belongs to space '${conflict.spaceKey}'`,
+            });
+          }
+        }
+
+        await db
+          .updateTable("community_spaces")
+          .set({
+            ...(name !== undefined ? { name } : {}),
+            ...(description !== undefined ? { description } : {}),
+            ...(readAccess !== undefined ? { read_access: readAccess } : {}),
+            ...(writeAccess !== undefined ? { write_access: writeAccess } : {}),
+            ...(collections !== undefined
+              ? { collections: JSON.stringify(collections) }
+              : {}),
+            updated_at: new Date(),
+          })
+          .where("community_did", "=", communityDid)
+          .where("space_key", "=", spaceKey)
+          .execute();
+
+        const updated = (await getSpace(db, communityDid, spaceKey))!;
+        await mirrorSpaceRecord(communityDid, updated);
+
+        await auditLog.log({
+          communityDid,
+          adminDid,
+          action: "space.updated",
+          metadata: { spaceKey },
+        });
+
+        res.json({ space: serializeSpace(updated) });
+      } catch (error: any) {
+        logger.error({ error, communityDid, spaceKey }, "Error updating space");
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to update space" });
+      }
+    },
+  );
+
+  // ─── DELETE /:did/spaces/:spaceKey ────────────────────────────────────
+  router.delete(
+    "/:did/spaces/:spaceKey",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      const spaceKey = req.params.spaceKey;
+      try {
+        const parsed = deleteSpaceSchema.safeParse(req.body);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid input", details: parsed.error.flatten() });
+        }
+        const { adminDid } = parsed.data;
+
+        if (!(await requireCommunityAndVisibility(req, res, communityDid)))
+          return;
+        if (!(await requireAdmin(communityDid, adminDid, res))) return;
+
+        const space = await getSpace(db, communityDid, spaceKey);
+        if (!space) {
+          return res.status(404).json({ error: "Space not found" });
+        }
+
+        await db
+          .deleteFrom("space_invites")
+          .where("community_did", "=", communityDid)
+          .where("space_key", "=", spaceKey)
+          .execute();
+        await db
+          .deleteFrom("community_spaces")
+          .where("community_did", "=", communityDid)
+          .where("space_key", "=", spaceKey)
+          .execute();
+        await deleteSpaceRecord(communityDid, spaceKey);
+
+        await auditLog.log({
+          communityDid,
+          adminDid,
+          action: "space.deleted",
+          metadata: { spaceKey },
+        });
+
+        res.json({ success: true });
+      } catch (error: any) {
+        logger.error({ error, communityDid, spaceKey }, "Error deleting space");
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to delete space" });
+      }
+    },
+  );
+
+  // ─── POST /:did/spaces/:spaceKey/invites — invite ─────────────────────
+  router.post(
+    "/:did/spaces/:spaceKey/invites",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      const spaceKey = req.params.spaceKey;
+      try {
+        const parsed = createSpaceInviteSchema.safeParse(req.body);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid input", details: parsed.error.flatten() });
+        }
+        const { adminDid, inviteeDid } = parsed.data;
+
+        if (!(await requireCommunityAndVisibility(req, res, communityDid)))
+          return;
+        if (!(await requireAdmin(communityDid, adminDid, res))) return;
+
+        const space = await getSpace(db, communityDid, spaceKey);
+        if (!space) {
+          return res.status(404).json({ error: "Space not found" });
+        }
+
+        await db
+          .insertInto("space_invites")
+          .values({
+            community_did: communityDid,
+            space_key: spaceKey,
+            invitee_did: inviteeDid,
+            invited_by: adminDid,
+          })
+          .onConflict((oc) =>
+            oc
+              .columns(["community_did", "space_key", "invitee_did"])
+              .doNothing(),
+          )
+          .execute();
+
+        await auditLog.log({
+          communityDid,
+          adminDid,
+          action: "space.invite.created",
+          targetDid: inviteeDid,
+          metadata: { spaceKey },
+        });
+
+        res.status(201).json({ success: true, spaceKey, inviteeDid });
+      } catch (error: any) {
+        logger.error(
+          { error, communityDid, spaceKey },
+          "Error creating space invite",
+        );
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to create invite" });
+      }
+    },
+  );
+
+  // ─── GET /:did/spaces/:spaceKey/invites ───────────────────────────────
+  router.get(
+    "/:did/spaces/:spaceKey/invites",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      const spaceKey = req.params.spaceKey;
+      try {
+        const adminDid = req.query.adminDid as string | undefined;
+        if (!adminDid) {
+          return res
+            .status(400)
+            .json({ error: "adminDid query parameter is required" });
+        }
+
+        if (!(await requireCommunityAndVisibility(req, res, communityDid)))
+          return;
+        if (!(await requireAdmin(communityDid, adminDid, res))) return;
+
+        const space = await getSpace(db, communityDid, spaceKey);
+        if (!space) {
+          return res.status(404).json({ error: "Space not found" });
+        }
+
+        const invites = await db
+          .selectFrom("space_invites")
+          .selectAll()
+          .where("community_did", "=", communityDid)
+          .where("space_key", "=", spaceKey)
+          .orderBy("created_at", "desc")
+          .execute();
+
+        res.json({
+          invites: invites.map((i) => ({
+            inviteeDid: i.invitee_did,
+            invitedBy: i.invited_by,
+            createdAt: i.created_at,
+          })),
+        });
+      } catch (error: any) {
+        logger.error(
+          { error, communityDid, spaceKey },
+          "Error listing space invites",
+        );
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to list invites" });
+      }
+    },
+  );
+
+  // ─── DELETE /:did/spaces/:spaceKey/invites/:inviteeDid — revokeInvite ─
+  router.delete(
+    "/:did/spaces/:spaceKey/invites/:inviteeDid",
+    verifyApiKey,
+    async (req: AuthenticatedRequest, res) => {
+      const communityDid = decodeURIComponent(req.params.did);
+      const spaceKey = req.params.spaceKey;
+      const inviteeDid = decodeURIComponent(req.params.inviteeDid);
+      try {
+        const parsed = revokeSpaceInviteSchema.safeParse(req.body);
+        if (!parsed.success) {
+          return res
+            .status(400)
+            .json({ error: "Invalid input", details: parsed.error.flatten() });
+        }
+        const { adminDid } = parsed.data;
+
+        if (!(await requireCommunityAndVisibility(req, res, communityDid)))
+          return;
+        if (!(await requireAdmin(communityDid, adminDid, res))) return;
+
+        const result = await db
+          .deleteFrom("space_invites")
+          .where("community_did", "=", communityDid)
+          .where("space_key", "=", spaceKey)
+          .where("invitee_did", "=", inviteeDid)
+          .executeTakeFirst();
+
+        if (!result || result.numDeletedRows === BigInt(0)) {
+          return res.status(404).json({ error: "Invite not found" });
+        }
+
+        await auditLog.log({
+          communityDid,
+          adminDid,
+          action: "space.invite.revoked",
+          targetDid: inviteeDid,
+          metadata: { spaceKey },
+        });
+
+        res.json({ success: true });
+      } catch (error: any) {
+        logger.error(
+          { error, communityDid, spaceKey },
+          "Error revoking space invite",
+        );
+        res
+          .status(500)
+          .json({ error: error.message || "Failed to revoke invite" });
+      }
+    },
+  );
+
+  return router;
+}

--- a/src/services/auditLog.ts
+++ b/src/services/auditLog.ts
@@ -36,7 +36,12 @@ export type AuditAction =
   | "hierarchy.revoked"
   | "announcement.created"
   | "announcement.updated"
-  | "announcement.deleted";
+  | "announcement.deleted"
+  | "space.created"
+  | "space.updated"
+  | "space.deleted"
+  | "space.invite.created"
+  | "space.invite.revoked";
 
 export function createAuditLogService(db: Kysely<Database>) {
   async function log(params: {

--- a/src/services/spaces.test.ts
+++ b/src/services/spaces.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Unit tests for the spaces service (permissioned data Phase 1):
+ * policy evaluation (canReadSpace / canWriteSpace / enforceSpaceBoundary)
+ * and the space validation schemas.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  canReadSpace,
+  canWriteSpace,
+  enforceSpaceBoundary,
+  parseSpaceCollections,
+  type SpaceRow,
+} from "./spaces";
+import {
+  createSpaceSchema,
+  updateSpaceSchema,
+  spaceKeySchema,
+} from "../validation/schemas";
+
+// ─── Test helpers ─────────────────────────────────────────────────────
+
+function makeSpace(overrides: Partial<SpaceRow> = {}): SpaceRow {
+  return {
+    id: 1,
+    community_did: "did:plc:community",
+    space_key: "announcements",
+    name: "Announcements",
+    description: null,
+    space_type: "community.opensocial.space",
+    read_access: "member",
+    write_access: "admin",
+    collections: JSON.stringify(["community.opensocial.announcement"]),
+    created_by: "did:plc:admin",
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  } as SpaceRow;
+}
+
+/**
+ * Minimal chainable Kysely mock. `spaces` backs listSpaces (execute),
+ * `invite` backs isInvited (executeTakeFirst).
+ */
+function makeDb({ spaces = [] as SpaceRow[], invited = false } = {}): any {
+  const chain: any = {
+    selectFrom: vi.fn(() => chain),
+    select: vi.fn(() => chain),
+    selectAll: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    execute: vi.fn(async () => spaces),
+    executeTakeFirst: vi.fn(async () => (invited ? { id: 1 } : undefined)),
+  };
+  return chain;
+}
+
+const USER = "did:plc:user";
+
+describe("spaces service", () => {
+  describe("parseSpaceCollections", () => {
+    it("parses a JSON array of collections", () => {
+      const space = makeSpace({ collections: '["a.b.c","d.e.f"]' });
+      expect(parseSpaceCollections(space)).toEqual(["a.b.c", "d.e.f"]);
+    });
+
+    it("returns [] for malformed JSON", () => {
+      const space = makeSpace({ collections: "not json" });
+      expect(parseSpaceCollections(space)).toEqual([]);
+    });
+
+    it("returns [] for non-array JSON", () => {
+      const space = makeSpace({ collections: '{"a":1}' });
+      expect(parseSpaceCollections(space)).toEqual([]);
+    });
+  });
+
+  describe("canReadSpace", () => {
+    it("always allows admins", async () => {
+      const space = makeSpace({ read_access: "invite" });
+      expect(await canReadSpace(makeDb(), space, USER, ["admin"])).toBe(true);
+    });
+
+    it("allows anyone when read_access is public", async () => {
+      const space = makeSpace({ read_access: "public" });
+      expect(await canReadSpace(makeDb(), space, USER, [])).toBe(true);
+    });
+
+    it("allows members when read_access is member", async () => {
+      const space = makeSpace({ read_access: "member" });
+      expect(await canReadSpace(makeDb(), space, USER, ["member"])).toBe(true);
+    });
+
+    it("denies non-members when read_access is member", async () => {
+      const space = makeSpace({ read_access: "member" });
+      expect(await canReadSpace(makeDb(), space, USER, [])).toBe(false);
+    });
+
+    it("denies members when read_access is admin", async () => {
+      const space = makeSpace({ read_access: "admin" });
+      expect(await canReadSpace(makeDb(), space, USER, ["member"])).toBe(false);
+    });
+
+    it("allows invited users when read_access is invite", async () => {
+      const space = makeSpace({ read_access: "invite" });
+      expect(
+        await canReadSpace(makeDb({ invited: true }), space, USER, ["member"]),
+      ).toBe(true);
+    });
+
+    it("denies uninvited members when read_access is invite", async () => {
+      const space = makeSpace({ read_access: "invite" });
+      expect(
+        await canReadSpace(makeDb({ invited: false }), space, USER, ["member"]),
+      ).toBe(false);
+    });
+
+    it("allows users holding the custom role when read_access is a custom role", async () => {
+      const space = makeSpace({ read_access: "moderator" });
+      expect(
+        await canReadSpace(makeDb(), space, USER, ["member", "moderator"]),
+      ).toBe(true);
+    });
+
+    it("denies plain members when read_access is a custom role", async () => {
+      const space = makeSpace({ read_access: "moderator" });
+      expect(await canReadSpace(makeDb(), space, USER, ["member"])).toBe(false);
+    });
+  });
+
+  describe("canWriteSpace", () => {
+    it("allows admins when write_access is admin", () => {
+      expect(
+        canWriteSpace(makeSpace({ write_access: "admin" }), ["admin"]),
+      ).toBe(true);
+    });
+
+    it("denies members when write_access is admin", () => {
+      expect(
+        canWriteSpace(makeSpace({ write_access: "admin" }), ["member"]),
+      ).toBe(false);
+    });
+
+    it("allows members when write_access is member", () => {
+      expect(
+        canWriteSpace(makeSpace({ write_access: "member" }), ["member"]),
+      ).toBe(true);
+    });
+
+    it("allows custom role holders when write_access is that role", () => {
+      expect(
+        canWriteSpace(makeSpace({ write_access: "moderator" }), [
+          "member",
+          "moderator",
+        ]),
+      ).toBe(true);
+    });
+  });
+
+  describe("enforceSpaceBoundary", () => {
+    const COLLECTION = "community.opensocial.announcement";
+
+    it("allows any operation on collections outside all spaces", async () => {
+      const db = makeDb({ spaces: [] });
+      const result = await enforceSpaceBoundary(
+        db,
+        "did:plc:community",
+        "some.other.collection",
+        "create",
+        USER,
+        [],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("denies member reads when the owning space is invite-only", async () => {
+      const db = makeDb({
+        spaces: [makeSpace({ read_access: "invite" })],
+        invited: false,
+      });
+      const result = await enforceSpaceBoundary(
+        db,
+        "did:plc:community",
+        COLLECTION,
+        "read",
+        USER,
+        ["member"],
+      );
+      expect(result.allowed).toBe(false);
+      expect((result as any).reason).toContain("announcements");
+    });
+
+    it("allows member reads of a member-readable space", async () => {
+      const db = makeDb({ spaces: [makeSpace({ read_access: "member" })] });
+      const result = await enforceSpaceBoundary(
+        db,
+        "did:plc:community",
+        COLLECTION,
+        "read",
+        USER,
+        ["member"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("denies member writes to an admin-writable space", async () => {
+      const db = makeDb({ spaces: [makeSpace({ write_access: "admin" })] });
+      for (const op of ["create", "update", "delete"] as const) {
+        const result = await enforceSpaceBoundary(
+          db,
+          "did:plc:community",
+          COLLECTION,
+          op,
+          USER,
+          ["member"],
+        );
+        expect(result.allowed).toBe(false);
+      }
+    });
+
+    it("allows admin writes to an admin-writable space", async () => {
+      const db = makeDb({ spaces: [makeSpace({ write_access: "admin" })] });
+      const result = await enforceSpaceBoundary(
+        db,
+        "did:plc:community",
+        COLLECTION,
+        "create",
+        USER,
+        ["admin"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+  });
+});
+
+describe("space validation schemas", () => {
+  describe("spaceKeySchema", () => {
+    it("accepts lowercase slugs", () => {
+      expect(spaceKeySchema.safeParse("announcements").success).toBe(true);
+      expect(spaceKeySchema.safeParse("book-club-2026").success).toBe(true);
+    });
+
+    it("rejects uppercase, spaces, and leading hyphens", () => {
+      expect(spaceKeySchema.safeParse("Announcements").success).toBe(false);
+      expect(spaceKeySchema.safeParse("book club").success).toBe(false);
+      expect(spaceKeySchema.safeParse("-club").success).toBe(false);
+    });
+  });
+
+  describe("createSpaceSchema", () => {
+    const valid = {
+      adminDid: "did:plc:admin",
+      spaceKey: "reading-list",
+      name: "Reading List",
+      collections: ["community.opensocial.readingItem"],
+    };
+
+    it("accepts a valid payload with defaults", () => {
+      const result = createSpaceSchema.safeParse(valid);
+      expect(result.success).toBe(true);
+      expect(result.data!.readAccess).toBe("member");
+      expect(result.data!.writeAccess).toBe("admin");
+    });
+
+    it("accepts invite read access and custom role write access", () => {
+      const result = createSpaceSchema.safeParse({
+        ...valid,
+        readAccess: "invite",
+        writeAccess: "moderator",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects public write access", () => {
+      const result = createSpaceSchema.safeParse({
+        ...valid,
+        writeAccess: "public",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid collection NSIDs", () => {
+      const result = createSpaceSchema.safeParse({
+        ...valid,
+        collections: ["not a collection"],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("requires at least one collection", () => {
+      const result = createSpaceSchema.safeParse({ ...valid, collections: [] });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a missing adminDid", () => {
+      const { adminDid: _drop, ...rest } = valid;
+      expect(createSpaceSchema.safeParse(rest).success).toBe(false);
+    });
+  });
+
+  describe("updateSpaceSchema", () => {
+    it("requires at least one updatable field", () => {
+      const result = updateSpaceSchema.safeParse({ adminDid: "did:plc:admin" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a readAccess-only update", () => {
+      const result = updateSpaceSchema.safeParse({
+        adminDid: "did:plc:admin",
+        readAccess: "invite",
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/services/spaces.ts
+++ b/src/services/spaces.ts
@@ -1,0 +1,205 @@
+/**
+ * Spaces service (permissioned data Phase 1).
+ *
+ * A space is a named access boundary around one or more collections in the
+ * community's repo. The registry lives in `community_spaces`; invite-only
+ * spaces keep their invite list in `space_invites`.
+ *
+ * Space policies are enforced as an ADDITIONAL gate on top of the existing
+ * per-app collection permissions — a space can only tighten access, never
+ * loosen it. See `enforceSpaceBoundary`.
+ */
+
+import type { Kysely, Selectable } from "kysely";
+import type { CommunitySpace, Database } from "../db";
+import {
+  ROLE_ADMIN,
+  ROLE_MEMBER,
+  satisfiesRole,
+  type Operation,
+} from "./permissions";
+import { logger } from "../lib/logger";
+
+export const SPACE_COLLECTION = "community.opensocial.space";
+export const ANNOUNCEMENTS_SPACE_KEY = "announcements";
+export const ANNOUNCEMENT_COLLECTION = "community.opensocial.announcement";
+
+/** Read-access levels with special semantics (anything else is a custom role). */
+export const READ_PUBLIC = "public";
+export const READ_INVITE = "invite";
+
+export type SpaceRow = Selectable<CommunitySpace>;
+
+export function parseSpaceCollections(space: SpaceRow): string[] {
+  try {
+    const parsed = JSON.parse(space.collections);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function listSpaces(
+  db: Kysely<Database>,
+  communityDid: string,
+): Promise<SpaceRow[]> {
+  return db
+    .selectFrom("community_spaces")
+    .selectAll()
+    .where("community_did", "=", communityDid)
+    .orderBy("space_key", "asc")
+    .execute();
+}
+
+export async function getSpace(
+  db: Kysely<Database>,
+  communityDid: string,
+  spaceKey: string,
+): Promise<SpaceRow | undefined> {
+  return db
+    .selectFrom("community_spaces")
+    .selectAll()
+    .where("community_did", "=", communityDid)
+    .where("space_key", "=", spaceKey)
+    .executeTakeFirst();
+}
+
+/**
+ * Find the space (if any) that claims a collection. Collections can belong
+ * to at most one space — enforced at space create/update time.
+ */
+export async function getSpaceForCollection(
+  db: Kysely<Database>,
+  communityDid: string,
+  collection: string,
+): Promise<SpaceRow | undefined> {
+  const spaces = await listSpaces(db, communityDid);
+  return spaces.find((s) => parseSpaceCollections(s).includes(collection));
+}
+
+export async function isInvited(
+  db: Kysely<Database>,
+  communityDid: string,
+  spaceKey: string,
+  userDid: string,
+): Promise<boolean> {
+  const row = await db
+    .selectFrom("space_invites")
+    .select("id")
+    .where("community_did", "=", communityDid)
+    .where("space_key", "=", spaceKey)
+    .where("invitee_did", "=", userDid)
+    .executeTakeFirst();
+  return row !== undefined;
+}
+
+/**
+ * Can a user with `userRoles` read records in this space?
+ *
+ * - admins can always read
+ * - 'public'  → anyone
+ * - 'member'  → member or admin
+ * - 'admin'   → admins only
+ * - 'invite'  → explicit invitees (and admins)
+ * - custom    → that role (and admins)
+ */
+export async function canReadSpace(
+  db: Kysely<Database>,
+  space: SpaceRow,
+  userDid: string,
+  userRoles: string[],
+): Promise<boolean> {
+  if (userRoles.includes(ROLE_ADMIN)) return true;
+  if (space.read_access === READ_PUBLIC) return true;
+  if (space.read_access === READ_INVITE) {
+    return isInvited(db, space.community_did, space.space_key, userDid);
+  }
+  if (space.read_access === ROLE_MEMBER) {
+    return userRoles.includes(ROLE_MEMBER);
+  }
+  if (space.read_access === ROLE_ADMIN) {
+    return false; // admin already handled above
+  }
+  return satisfiesRole(userRoles, space.read_access);
+}
+
+/** Can a user with `userRoles` write (create/update/delete) in this space? */
+export function canWriteSpace(space: SpaceRow, userRoles: string[]): boolean {
+  return satisfiesRole(userRoles, space.write_access);
+}
+
+export type SpaceBoundaryResult =
+  | { allowed: true }
+  | { allowed: false; reason: string };
+
+/**
+ * The space gate used by the record-access paths: if `collection` belongs
+ * to a space, the space's policy must ALSO be satisfied (on top of the
+ * per-app collection permissions). Collections outside any space are
+ * unaffected.
+ */
+export async function enforceSpaceBoundary(
+  db: Kysely<Database>,
+  communityDid: string,
+  collection: string,
+  operation: Operation,
+  userDid: string,
+  userRoles: string[],
+): Promise<SpaceBoundaryResult> {
+  const space = await getSpaceForCollection(db, communityDid, collection);
+  if (!space) return { allowed: true };
+
+  if (operation === "read") {
+    const ok = await canReadSpace(db, space, userDid, userRoles);
+    if (!ok) {
+      return {
+        allowed: false,
+        reason: `Collection belongs to space '${space.space_key}' (read access: ${space.read_access})`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  if (!canWriteSpace(space, userRoles)) {
+    return {
+      allowed: false,
+      reason: `Collection belongs to space '${space.space_key}' (write access: ${space.write_access})`,
+    };
+  }
+  return { allowed: true };
+}
+
+/**
+ * Register the built-in spaces for a community (currently the announcement
+ * space). Called at community creation; idempotent.
+ */
+export async function ensureDefaultSpaces(
+  db: Kysely<Database>,
+  communityDid: string,
+  creatorDid: string,
+): Promise<void> {
+  try {
+    await db
+      .insertInto("community_spaces")
+      .values({
+        community_did: communityDid,
+        space_key: ANNOUNCEMENTS_SPACE_KEY,
+        name: "Announcements",
+        description: "Group-only announcements from the community admins",
+        space_type: SPACE_COLLECTION,
+        read_access: ROLE_MEMBER,
+        write_access: ROLE_ADMIN,
+        collections: JSON.stringify([ANNOUNCEMENT_COLLECTION]),
+        created_by: creatorDid,
+      })
+      .onConflict((oc) =>
+        oc.columns(["community_did", "space_key"]).doNothing(),
+      )
+      .execute();
+  } catch (err) {
+    logger.warn(
+      { error: err, communityDid },
+      "Failed to seed default spaces for new community",
+    );
+  }
+}

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -375,3 +375,73 @@ export const revokeRoleSchema = z.object({
   memberDid: didSchema,
   roleName: z.string().min(1),
 });
+
+// ─── Space schemas (permissioned data Phase 1) ────────────────────────
+
+export const spaceKeySchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(
+    /^[a-z0-9][a-z0-9-]*$/,
+    "Space key must be lowercase alphanumeric with hyphens",
+  );
+
+/** 'public' | 'member' | 'admin' | 'invite' | custom role name */
+export const spaceReadAccessSchema = z
+  .enum(["public", "member", "admin", "invite"])
+  .or(z.string().min(1).max(100));
+
+/** 'member' | 'admin' | custom role name — 'public'/'invite' make no sense for writes */
+export const spaceWriteAccessSchema = z.enum(["member", "admin"]).or(
+  z
+    .string()
+    .min(1)
+    .max(100)
+    .refine((v) => v !== "public" && v !== "invite", {
+      message: "writeAccess must be 'member', 'admin', or a custom role name",
+    }),
+);
+
+export const createSpaceSchema = z.object({
+  adminDid: didSchema,
+  spaceKey: spaceKeySchema,
+  name: z.string().min(1).max(128),
+  description: z.string().max(512).optional(),
+  spaceType: nsidSchema.optional(),
+  readAccess: spaceReadAccessSchema.default("member"),
+  writeAccess: spaceWriteAccessSchema.default("admin"),
+  collections: z.array(nsidSchema).min(1).max(16),
+});
+
+export const updateSpaceSchema = z
+  .object({
+    adminDid: didSchema,
+    name: z.string().min(1).max(128).optional(),
+    description: z.string().max(512).optional(),
+    readAccess: spaceReadAccessSchema.optional(),
+    writeAccess: spaceWriteAccessSchema.optional(),
+    collections: z.array(nsidSchema).min(1).max(16).optional(),
+  })
+  .refine(
+    (data) =>
+      data.name !== undefined ||
+      data.description !== undefined ||
+      data.readAccess !== undefined ||
+      data.writeAccess !== undefined ||
+      data.collections !== undefined,
+    { message: "At least one field is required" },
+  );
+
+export const deleteSpaceSchema = z.object({
+  adminDid: didSchema,
+});
+
+export const createSpaceInviteSchema = z.object({
+  adminDid: didSchema,
+  inviteeDid: didSchema,
+});
+
+export const revokeSpaceInviteSchema = z.object({
+  adminDid: didSchema,
+});


### PR DESCRIPTION
## Summary

**Stacked on #85** — review that first; this PR's diff is only the spaces work.

Implements Phase 1 of [docs/PERMISSIONED_DATA.md](../blob/claude/permissioned-data-spaces-or2t6s/docs/PERMISSIONED_DATA.md): spaces become explicit objects with declared access policies, instead of implicit gated collections. This closes the three gaps identified in the [group management methods discussion](https://discourse.atprotocol.community/t/another-follow-up-topic-group-management-methods/941): `listGroupSpaces`, `createGroupSpace`, and `invite`/`revokeInvite`.

### What's a space

A named access boundary around one or more collections in the community's repo:

- **Registry** (`community_spaces`, migration 016): space key, name, space type NSID, `readAccess` (`public` | `member` | `admin` | `invite` | custom role), `writeAccess` (`member` | `admin` | custom role), declared collections. `space_invites` holds the explicit invite list for invite-only spaces.
- **On-protocol mirror**: definitions are written to the community repo as `community.opensocial.space` records (rkey = space key) for discoverability; the database registry stays authoritative for enforcement.
- **Enforcement**: space policies run as an *additional* gate in the records and announcements permission paths — a space can tighten access beyond the per-app collection permissions (e.g. invite-only reads), never loosen it.
- **Defaults**: the announcement space from #85 becomes registry row #1 — backfilled for existing communities, seeded for new ones via `ensureDefaultSpaces`.

### Endpoints (`/api/v1/communities/:did/spaces`, API key; mutations admin-gated, audit-logged)

| Method | Purpose |
| --- | --- |
| `GET /` | `listGroupSpaces` — optional `userDid` adds per-space `canRead`/`canWrite` |
| `POST /` | `createGroupSpace` — declare collections + read/write policy (collections can belong to at most one space; 409 on conflict) |
| `GET /:spaceKey` / `PUT /:spaceKey` / `DELETE /:spaceKey` | Space details / update / delete |
| `POST /:spaceKey/invites` / `GET /:spaceKey/invites` / `DELETE /:spaceKey/invites/:inviteeDid` | `invite` / list / `revokeInvite` for invite-only spaces |

## Testing

- 454/454 tests pass (31 new: space policy evaluation — public/member/admin/invite/custom-role reads, write gating, boundary enforcement — plus validation schemas)
- Migration 016 verified up/down/up against Postgres 16
- Typecheck clean

## Follow-ups (not in this PR)

- XRPC parity for the space methods (`community.opensocial.listSpaces` etc.)
- Phase 2 of the roadmap: delegation tokens + space credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWBtUTFK3YtbtxDPQKxn5x

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWBtUTFK3YtbtxDPQKxn5x)_