### PR TITLE
Add Open Graph share cards for communities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "@atproto/identity": "^0.4.12",
         "@atproto/oauth-client-node": "^0.3.13",
         "@atproto/xrpc-server": "^0.10.20",
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/vollkorn": "^5.2.10",
+        "@resvg/resvg-js": "^2.6.2",
         "@types/cookie-parser": "^1.4.10",
         "@types/multer": "^2.0.0",
         "bcrypt": "^6.0.0",
@@ -31,6 +34,7 @@
         "pino": "^9.5.0",
         "pino-pretty": "^11.3.0",
         "sanitize-html": "^2.17.0",
+        "satori": "^0.26.0",
         "uuid": "^13.0.0",
         "ws": "^8.20.0",
         "zod": "^4.3.6"
@@ -1539,6 +1543,24 @@
         "npm": ">=10"
       }
     },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/vollkorn": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/vollkorn/-/vollkorn-5.2.10.tgz",
+      "integrity": "sha512-gSlz1yYmGkpSnfchXwbdkCnGFGnV2lKhA0Wc87kF95kA5ziOGLHCriQvDKZhExVC4/heeB6MdmVdyIW/e9Ab6A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1609,6 +1631,221 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -1959,6 +2196,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2685,6 +2938,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2752,6 +3014,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2924,6 +3192,47 @@
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
       "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
       "license": "ISC"
+    },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "node_modules/dateformat": {
       "version": "4.6.3",
@@ -3102,6 +3411,15 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -3407,6 +3725,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3684,6 +4008,18 @@
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -4072,6 +4408,25 @@
       },
       "bin": {
         "kysely-migration-cli": "bin/kysely-migration-cli.js"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lint-staged": {
@@ -4623,6 +4978,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
@@ -4852,6 +5223,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -5196,6 +5573,28 @@
         "postcss": "^8.3.11"
       }
     },
+    "node_modules/satori": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+      "integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -5481,6 +5880,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
+    },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -5566,6 +5971,12 @@
       "dependencies": {
         "real-require": "^0.2.0"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5785,6 +6196,16 @@
       "resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
       "integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -6133,6 +6554,12 @@
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "@atproto/identity": "^0.4.12",
     "@atproto/oauth-client-node": "^0.3.13",
     "@atproto/xrpc-server": "^0.10.20",
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/vollkorn": "^5.2.10",
+    "@resvg/resvg-js": "^2.6.2",
     "@types/cookie-parser": "^1.4.10",
     "@types/multer": "^2.0.0",
     "bcrypt": "^6.0.0",
@@ -50,6 +53,7 @@
     "pino": "^9.5.0",
     "pino-pretty": "^11.3.0",
     "sanitize-html": "^2.17.0",
+    "satori": "^0.26.0",
     "uuid": "^13.0.0",
     "ws": "^8.20.0",
     "zod": "^4.3.6"

--- a/scripts/generate-og-default.ts
+++ b/scripts/generate-og-default.ts
@@ -1,0 +1,21 @@
+// scripts/generate-og-default.ts
+/**
+ * Renders the generic OG fallback card used by the web app's static
+ * og:image tag. Usage: npx tsx scripts/generate-og-default.ts <output-path>
+ */
+import { writeFileSync } from "fs";
+import { renderDefaultCard } from "../src/services/ogImage";
+
+async function main() {
+  const outPath = process.argv[2];
+  if (!outPath) {
+    console.error(
+      "Usage: npx tsx scripts/generate-og-default.ts <output-path>",
+    );
+    process.exit(1);
+  }
+  writeFileSync(outPath, await renderDefaultCard());
+  console.log(`Wrote ${outPath}`);
+}
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,8 +107,9 @@ async function start() {
     // Auth routes (OAuth)
     app.use(createAuthRouter(oauthClient, db));
 
-    // Public OG share-card endpoints (no auth — consumed by link-preview crawlers)
-    app.use(createOgRouter(db));
+    // Public OG share-card endpoints (no auth — consumed by link-preview crawlers).
+    // Rate-limited: each request can trigger DB + PLC + PDS + Bluesky calls.
+    app.use(createOgRouter(db, rateLimiter));
 
     // API routes
     app.get("/health", (req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { createStreamRouter } from "./routes/stream";
 import { createPermissionsRouter } from "./routes/permissions";
 import { createHierarchyRouter } from "./routes/hierarchy";
 import { createEventsRouter } from "./routes/events";
+import { createOgRouter } from "./routes/og";
 import { createXrpcRouter } from "./xrpc/server";
 import { createRateLimiter } from "./middleware/rateLimit";
 import { csrfProtection } from "./middleware/csrf";
@@ -105,6 +106,9 @@ async function start() {
 
     // Auth routes (OAuth)
     app.use(createAuthRouter(oauthClient, db));
+
+    // Public OG share-card endpoints (no auth — consumed by link-preview crawlers)
+    app.use(createOgRouter(db));
 
     // API routes
     app.get("/health", (req, res) => {

--- a/src/lib/ogAvatar.test.ts
+++ b/src/lib/ogAvatar.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { preferJpegCdnUrl, fetchAvatarAsDataUri } from "./ogAvatar";
+
+const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const WEBP_BYTES = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+]);
+
+function mockFetchOk(bytes: Uint8Array) {
+  return vi.fn(async () => ({
+    ok: true,
+    arrayBuffer: async () => bytes.buffer,
+  })) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("preferJpegCdnUrl", () => {
+  it("appends @jpeg to bare cdn.bsky.app image URLs", () => {
+    expect(
+      preferJpegCdnUrl(
+        "https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafyabc",
+      ),
+    ).toBe("https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafyabc@jpeg");
+  });
+
+  it("leaves cdn URLs that already have a format suffix alone", () => {
+    const url = "https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafyabc@jpeg";
+    expect(preferJpegCdnUrl(url)).toBe(url);
+  });
+
+  it("leaves non-CDN URLs alone", () => {
+    const url =
+      "https://pds.example.com/xrpc/com.atproto.sync.getBlob?did=x&cid=y";
+    expect(preferJpegCdnUrl(url)).toBe(url);
+  });
+
+  it("returns invalid URLs unchanged", () => {
+    expect(preferJpegCdnUrl("not a url")).toBe("not a url");
+  });
+});
+
+describe("fetchAvatarAsDataUri", () => {
+  it("returns a jpeg data URI for jpeg bytes", async () => {
+    vi.stubGlobal("fetch", mockFetchOk(JPEG_BYTES));
+    const uri = await fetchAvatarAsDataUri("https://example.com/a.jpg");
+    expect(uri).toMatch(/^data:image\/jpeg;base64,/);
+    expect(uri).toContain(Buffer.from(JPEG_BYTES).toString("base64"));
+  });
+
+  it("returns a png data URI for png bytes", async () => {
+    vi.stubGlobal("fetch", mockFetchOk(PNG_BYTES));
+    const uri = await fetchAvatarAsDataUri("https://example.com/a.png");
+    expect(uri).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("returns undefined for webp bytes (satori cannot decode them)", async () => {
+    vi.stubGlobal("fetch", mockFetchOk(WEBP_BYTES));
+    expect(
+      await fetchAvatarAsDataUri("https://example.com/a.webp"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined on non-ok responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        arrayBuffer: async () => new ArrayBuffer(0),
+      })),
+    );
+    expect(
+      await fetchAvatarAsDataUri("https://example.com/404.jpg"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when fetch throws (network error / abort)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("aborted");
+      }),
+    );
+    expect(
+      await fetchAvatarAsDataUri("https://example.com/slow.jpg"),
+    ).toBeUndefined();
+  });
+
+  it("requests the @jpeg variant of bare cdn.bsky.app URLs", async () => {
+    const fetchMock = mockFetchOk(JPEG_BYTES);
+    vi.stubGlobal("fetch", fetchMock);
+    await fetchAvatarAsDataUri(
+      "https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafyabc",
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafyabc@jpeg",
+      expect.anything(),
+    );
+  });
+});

--- a/src/lib/ogAvatar.test.ts
+++ b/src/lib/ogAvatar.test.ts
@@ -34,6 +34,11 @@ describe("preferJpegCdnUrl", () => {
     expect(preferJpegCdnUrl(url)).toBe(url);
   });
 
+  it("leaves cdn URLs with an @webp suffix alone (no @webp@jpeg)", () => {
+    const url = "https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafyabc@webp";
+    expect(preferJpegCdnUrl(url)).toBe(url);
+  });
+
   it("leaves non-CDN URLs alone", () => {
     const url =
       "https://pds.example.com/xrpc/com.atproto.sync.getBlob?did=x&cid=y";
@@ -100,6 +105,16 @@ describe("fetchAvatarAsDataUri", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafyabc@jpeg",
       expect.anything(),
+    );
+  });
+
+  it("fetches with redirect: 'error' so an allowlisted host can't redirect elsewhere", async () => {
+    const fetchMock = mockFetchOk(JPEG_BYTES);
+    vi.stubGlobal("fetch", fetchMock);
+    await fetchAvatarAsDataUri("https://example.com/a.jpg");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/a.jpg",
+      expect.objectContaining({ redirect: "error" }),
     );
   });
 });

--- a/src/lib/ogAvatar.ts
+++ b/src/lib/ogAvatar.ts
@@ -1,0 +1,78 @@
+import { logger } from "./logger";
+
+/**
+ * cdn.bsky.app serves WebP by default, which satori/resvg cannot decode.
+ * Appending "@jpeg" to the image path asks the CDN to transcode to JPEG.
+ */
+export function preferJpegCdnUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.hostname === "cdn.bsky.app" && !/@(jpeg|png)$/.test(u.pathname)) {
+      return `${u.origin}${u.pathname}@jpeg${u.search}`;
+    }
+  } catch {
+    // Not a parseable URL — return as-is and let fetch fail downstream.
+  }
+  return url;
+}
+
+function sniffImageMime(buf: Buffer): string | undefined {
+  if (
+    buf.length >= 3 &&
+    buf[0] === 0xff &&
+    buf[1] === 0xd8 &&
+    buf[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  if (
+    buf.length >= 4 &&
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  if (
+    buf.length >= 4 &&
+    buf[0] === 0x47 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x38
+  ) {
+    return "image/gif";
+  }
+  return undefined; // WebP or anything else satori can't embed
+}
+
+/**
+ * Fetch an avatar and return it as a data URI for embedding in a satori
+ * layout. Returns undefined on any failure (timeout, non-image, WebP, …)
+ * so callers can fall back to a monogram card.
+ */
+export async function fetchAvatarAsDataUri(
+  url: string,
+  timeoutMs = 3000,
+): Promise<string | undefined> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(preferJpegCdnUrl(url), {
+      signal: controller.signal,
+    });
+    if (!res.ok) return undefined;
+    const buf = Buffer.from(await res.arrayBuffer());
+    const mime = sniffImageMime(buf);
+    if (!mime) {
+      logger.warn({ url }, "Avatar is not a satori-embeddable image type");
+      return undefined;
+    }
+    return `data:${mime};base64,${buf.toString("base64")}`;
+  } catch (err) {
+    logger.warn({ error: err, url }, "Failed to fetch avatar for OG card");
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/ogAvatar.ts
+++ b/src/lib/ogAvatar.ts
@@ -7,7 +7,7 @@ import { logger } from "./logger";
 export function preferJpegCdnUrl(url: string): string {
   try {
     const u = new URL(url);
-    if (u.hostname === "cdn.bsky.app" && !/@(jpeg|png)$/.test(u.pathname)) {
+    if (u.hostname === "cdn.bsky.app" && !/@\w+$/.test(u.pathname)) {
       return `${u.origin}${u.pathname}@jpeg${u.search}`;
     }
   } catch {
@@ -60,6 +60,10 @@ export async function fetchAvatarAsDataUri(
   try {
     const res = await fetch(preferJpegCdnUrl(url), {
       signal: controller.signal,
+      // Even an allowlisted host shouldn't be able to redirect this
+      // server-side fetch elsewhere (SSRF via open redirect). Treat a
+      // redirect as a failure and fall back to the monogram card.
+      redirect: "error",
     });
     if (!res.ok) return undefined;
     const buf = Buffer.from(await res.arrayBuffer());

--- a/src/routes/og.test.ts
+++ b/src/routes/og.test.ts
@@ -130,6 +130,19 @@ describe("GET /communities/:did/share", () => {
     expect(res.text).not.toContain("<Roll>");
   });
 
+  it("escapes host-derived og:image URLs against Host-header injection", async () => {
+    vi.mocked(getCommunityCardData).mockResolvedValue({ displayName: "Test" });
+
+    const res = await supertest(buildApp())
+      .get(`/communities/${ENCODED}/share`)
+      .set("Host", 'evil.example"><script>alert(1)</script>');
+
+    expect(res.status).toBe(200);
+    // The raw Host header must never break out of the attribute.
+    expect(res.text).not.toContain('"><script>');
+    expect(res.text).toContain("&quot;&gt;&lt;script&gt;");
+  });
+
   it("uses the fallback description when the community has none", async () => {
     vi.mocked(getCommunityCardData).mockResolvedValue({
       displayName: "Quiet Club",

--- a/src/routes/og.test.ts
+++ b/src/routes/og.test.ts
@@ -163,3 +163,25 @@ describe("GET /communities/:did/share", () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe("optional rate limiter", () => {
+  it("is invoked for both og-image and share requests when supplied", async () => {
+    vi.mocked(getCommunityCardData).mockResolvedValue({ displayName: "Test" });
+    const rateLimiter = vi.fn((req: any, res: any, next: any) => next());
+
+    const app = express();
+    app.use(createOgRouter({} as any, rateLimiter));
+
+    const imageDid = "did:plc:ratelimit000000000000001";
+    await supertest(app).get(
+      `/communities/${encodeURIComponent(imageDid)}/og-image`,
+    );
+    expect(rateLimiter).toHaveBeenCalledTimes(1);
+
+    const shareDid = "did:plc:ratelimit000000000000002";
+    await supertest(app).get(
+      `/communities/${encodeURIComponent(shareDid)}/share`,
+    );
+    expect(rateLimiter).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/routes/og.test.ts
+++ b/src/routes/og.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import supertest from "supertest";
+import express from "express";
+import { createOgRouter, escapeHtml } from "./og";
+
+vi.mock("../services/ogCard", () => ({ getCommunityCardData: vi.fn() }));
+vi.mock("../services/ogImage", () => ({ renderCommunityCard: vi.fn() }));
+vi.mock("../lib/ogAvatar", () => ({
+  fetchAvatarAsDataUri: vi.fn(async () => undefined),
+}));
+
+import { getCommunityCardData } from "../services/ogCard";
+import { renderCommunityCard } from "../services/ogImage";
+import { fetchAvatarAsDataUri } from "../lib/ogAvatar";
+
+const FAKE_PNG = Buffer.from("fake-png-bytes");
+
+function buildApp() {
+  const app = express();
+  app.use(createOgRouter({} as any));
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(renderCommunityCard).mockResolvedValue(FAKE_PNG);
+});
+
+describe("escapeHtml", () => {
+  it("escapes HTML metacharacters", () => {
+    expect(escapeHtml(`Rock & <Roll> "Club" 'n stuff`)).toBe(
+      "Rock &amp; &lt;Roll&gt; &quot;Club&quot; &#39;n stuff",
+    );
+  });
+});
+
+describe("GET /communities/:did/og-image", () => {
+  it("returns the rendered PNG with cache headers", async () => {
+    // Unique DID per test — the route keeps a module-level PNG cache.
+    const did = "did:plc:png0000000000000000001";
+    vi.mocked(getCommunityCardData).mockResolvedValue({ displayName: "Test" });
+
+    const res = await supertest(buildApp()).get(
+      `/communities/${encodeURIComponent(did)}/og-image`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("image/png");
+    expect(res.headers["cache-control"]).toBe("public, max-age=3600");
+    expect(res.body).toEqual(FAKE_PNG);
+  });
+
+  it("passes the fetched avatar data URI to the renderer", async () => {
+    const did = "did:plc:png0000000000000000002";
+    vi.mocked(getCommunityCardData).mockResolvedValue({
+      displayName: "Test",
+      avatarUrl: "https://cdn.bsky.app/img/a",
+    });
+    vi.mocked(fetchAvatarAsDataUri).mockResolvedValue(
+      "data:image/jpeg;base64,xyz",
+    );
+
+    await supertest(buildApp()).get(
+      `/communities/${encodeURIComponent(did)}/og-image`,
+    );
+
+    expect(fetchAvatarAsDataUri).toHaveBeenCalledWith(
+      "https://cdn.bsky.app/img/a",
+    );
+    expect(renderCommunityCard).toHaveBeenCalledWith({
+      displayName: "Test",
+      avatarDataUri: "data:image/jpeg;base64,xyz",
+    });
+  });
+
+  it("serves repeat requests from the in-memory cache", async () => {
+    const did = "did:plc:png0000000000000000003";
+    vi.mocked(getCommunityCardData).mockResolvedValue({ displayName: "Test" });
+
+    const app = buildApp();
+    await supertest(app).get(
+      `/communities/${encodeURIComponent(did)}/og-image`,
+    );
+    const second = await supertest(app).get(
+      `/communities/${encodeURIComponent(did)}/og-image`,
+    );
+
+    expect(second.status).toBe(200);
+    expect(renderCommunityCard).toHaveBeenCalledTimes(1);
+  });
+
+  it("404s for unknown communities", async () => {
+    vi.mocked(getCommunityCardData).mockResolvedValue(null);
+    const res = await supertest(buildApp()).get(
+      "/communities/did%3Aplc%3Amissing0000000000001/og-image",
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /communities/:did/share", () => {
+  const DID = "did:plc:share00000000000000001";
+  const ENCODED = encodeURIComponent(DID);
+
+  it("serves OG meta tags with escaped values and a redirect", async () => {
+    vi.mocked(getCommunityCardData).mockResolvedValue({
+      displayName: 'Rock & <Roll> "Club"',
+      description: "Loud & proud.",
+    });
+
+    const res = await supertest(buildApp()).get(
+      `/communities/${ENCODED}/share`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/html");
+    expect(res.headers["cache-control"]).toBe("public, max-age=300");
+    expect(res.text).toContain(
+      'og:title" content="Join Rock &amp; &lt;Roll&gt; &quot;Club&quot; on Open Social"',
+    );
+    expect(res.text).toContain('og:description" content="Loud &amp; proud."');
+    expect(res.text).toContain(`/communities/${ENCODED}/og-image`);
+    expect(res.text).toContain(
+      'name="twitter:card" content="summary_large_image"',
+    );
+    // Redirect target preserves the join flow.
+    expect(res.text).toContain(`/communities/${ENCODED}?action=join`);
+    expect(res.text).toContain("http-equiv=");
+    // Raw name must never appear unescaped.
+    expect(res.text).not.toContain("<Roll>");
+  });
+
+  it("uses the fallback description when the community has none", async () => {
+    vi.mocked(getCommunityCardData).mockResolvedValue({
+      displayName: "Quiet Club",
+    });
+    const res = await supertest(buildApp()).get(
+      `/communities/${ENCODED}/share`,
+    );
+    expect(res.text).toContain(
+      'og:description" content="Join this community on Open Social."',
+    );
+  });
+
+  it("404s for unknown communities", async () => {
+    vi.mocked(getCommunityCardData).mockResolvedValue(null);
+    const res = await supertest(buildApp()).get(
+      `/communities/${ENCODED}/share`,
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/routes/og.ts
+++ b/src/routes/og.ts
@@ -1,0 +1,130 @@
+import express, { Request, Response, NextFunction, Router } from "express";
+import type { Kysely } from "kysely";
+import type { Database } from "../db";
+import { config } from "../config";
+import { getCommunityCardData } from "../services/ogCard";
+import { renderCommunityCard } from "../services/ogImage";
+import { fetchAvatarAsDataUri } from "../lib/ogAvatar";
+
+const PNG_CACHE_TTL_MS = 60 * 60 * 1000; // matches Cache-Control max-age=3600
+const PNG_CACHE_MAX_ENTRIES = 500;
+const pngCache = new Map<string, { buf: Buffer; expires: number }>();
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** Public base URL of this API (for absolute og:image URLs). */
+function apiBaseUrl(req: Request): string {
+  return config.serviceUrl || `${req.protocol}://${req.get("host")}`;
+}
+
+/** Public base URL of the web app (redirect target). */
+function appBaseUrl(): string {
+  return config.corsOrigin || "http://127.0.0.1:5174";
+}
+
+/**
+ * Public OG share-card endpoints, consumed by link-preview crawlers.
+ * No auth: crawlers have no session, and the data shown is already public.
+ */
+export function createOgRouter(db: Kysely<Database>): Router {
+  const router = express.Router();
+
+  router.get(
+    "/communities/:did/og-image",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const did = decodeURIComponent(req.params.did);
+
+        const sendPng = (buf: Buffer) => {
+          res.setHeader("Content-Type", "image/png");
+          res.setHeader("Cache-Control", "public, max-age=3600");
+          res.send(buf);
+        };
+
+        const cached = pngCache.get(did);
+        if (cached && cached.expires > Date.now()) {
+          return sendPng(cached.buf);
+        }
+
+        const data = await getCommunityCardData(db, did);
+        if (!data) {
+          return res.status(404).json({ error: "Community not found" });
+        }
+
+        const avatarDataUri = data.avatarUrl
+          ? await fetchAvatarAsDataUri(data.avatarUrl)
+          : undefined;
+        const buf = await renderCommunityCard({
+          displayName: data.displayName,
+          avatarDataUri,
+        });
+
+        if (pngCache.size >= PNG_CACHE_MAX_ENTRIES) {
+          const oldest = pngCache.keys().next().value;
+          if (oldest !== undefined) pngCache.delete(oldest);
+        }
+        pngCache.set(did, { buf, expires: Date.now() + PNG_CACHE_TTL_MS });
+
+        sendPng(buf);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  router.get(
+    "/communities/:did/share",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const did = decodeURIComponent(req.params.did);
+        const data = await getCommunityCardData(db, did);
+        if (!data) {
+          return res.status(404).send("Community not found");
+        }
+
+        const encodedDid = encodeURIComponent(did);
+        const imageUrl = `${apiBaseUrl(req)}/communities/${encodedDid}/og-image`;
+        const targetUrl = `${appBaseUrl()}/communities/${encodedDid}?action=join`;
+        const title = escapeHtml(`Join ${data.displayName} on Open Social`);
+        const description = escapeHtml(
+          data.description || "Join this community on Open Social.",
+        );
+
+        res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.setHeader("Cache-Control", "public, max-age=300");
+        res.send(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${title}</title>
+<meta property="og:site_name" content="Open Social">
+<meta property="og:type" content="website">
+<meta property="og:title" content="${title}">
+<meta property="og:description" content="${description}">
+<meta property="og:image" content="${imageUrl}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:url" content="${escapeHtml(targetUrl)}">
+<meta name="twitter:card" content="summary_large_image">
+<meta http-equiv="refresh" content="0; url=${escapeHtml(targetUrl)}">
+</head>
+<body>
+<p>Redirecting to <a href="${escapeHtml(targetUrl)}">${title}</a>…</p>
+<script>window.location.replace(${JSON.stringify(targetUrl)});</script>
+</body>
+</html>`);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  return router;
+}

--- a/src/routes/og.ts
+++ b/src/routes/og.ts
@@ -32,12 +32,21 @@ function appBaseUrl(): string {
 /**
  * Public OG share-card endpoints, consumed by link-preview crawlers.
  * No auth: crawlers have no session, and the data shown is already public.
+ *
+ * These routes are unauthenticated and each request can trigger DB + PLC +
+ * PDS + Bluesky lookups (uncached on `/share`), so an optional rate limiter
+ * can be supplied to guard against amplification abuse.
  */
-export function createOgRouter(db: Kysely<Database>): Router {
+export function createOgRouter(
+  db: Kysely<Database>,
+  rateLimiter?: express.RequestHandler,
+): Router {
   const router = express.Router();
+  const middlewares = rateLimiter ? [rateLimiter] : [];
 
   router.get(
     "/communities/:did/og-image",
+    ...middlewares,
     async (req: Request, res: Response, next: NextFunction) => {
       try {
         const did = decodeURIComponent(req.params.did);
@@ -81,6 +90,7 @@ export function createOgRouter(db: Kysely<Database>): Router {
 
   router.get(
     "/communities/:did/share",
+    ...middlewares,
     async (req: Request, res: Response, next: NextFunction) => {
       try {
         const did = decodeURIComponent(req.params.did);

--- a/src/routes/og.ts
+++ b/src/routes/og.ts
@@ -108,7 +108,7 @@ export function createOgRouter(db: Kysely<Database>): Router {
 <meta property="og:type" content="website">
 <meta property="og:title" content="${title}">
 <meta property="og:description" content="${description}">
-<meta property="og:image" content="${imageUrl}">
+<meta property="og:image" content="${escapeHtml(imageUrl)}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:url" content="${escapeHtml(targetUrl)}">

--- a/src/services/ogCard.test.ts
+++ b/src/services/ogCard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getCommunityCardData } from "./ogCard";
+import { getCommunityCardData, isAllowedAvatarUrl } from "./ogCard";
 
 const DID = "did:plc:testcommunity000000001";
 
@@ -99,5 +99,89 @@ describe("getCommunityCardData", () => {
       DID,
     );
     expect(data?.displayName).toBe("test-community.bsky.social");
+  });
+
+  it("rejects a string avatar URL on a foreign host (SSRF guard)", async () => {
+    getRecordMock.mockResolvedValue({
+      data: { value: { avatar: "http://169.254.169.254/latest/meta-data" } },
+    });
+    vi.mocked(blobToUrl).mockReturnValue(
+      "http://169.254.169.254/latest/meta-data",
+    );
+    // The Bluesky fallback is also consulted once the profile avatar is
+    // rejected — make it explicit that it yields nothing here too.
+    vi.mocked(fetchBlueskyAvatar).mockResolvedValue(undefined);
+
+    const data = await getCommunityCardData(stubDb(ROW), DID);
+    expect(data?.avatarUrl).toBeUndefined();
+  });
+
+  it("keeps a string avatar URL whose host matches the community's pds_host", async () => {
+    getRecordMock.mockResolvedValue({
+      data: { value: { avatar: "https://pds.example.com/avatar.jpg" } },
+    });
+    vi.mocked(blobToUrl).mockReturnValue("https://pds.example.com/avatar.jpg");
+
+    const data = await getCommunityCardData(stubDb(ROW), DID);
+    expect(data?.avatarUrl).toBe("https://pds.example.com/avatar.jpg");
+  });
+
+  it("keeps a cdn.bsky.app URL from the Bluesky avatar fallback", async () => {
+    vi.mocked(fetchBlueskyAvatar).mockResolvedValue(
+      "https://cdn.bsky.app/img/a@jpeg",
+    );
+
+    const data = await getCommunityCardData(stubDb(ROW), DID);
+    expect(data?.avatarUrl).toBe("https://cdn.bsky.app/img/a@jpeg");
+  });
+
+  it("rejects a non-http(s) scheme avatar URL", async () => {
+    getRecordMock.mockResolvedValue({
+      data: { value: { avatar: "file:///etc/passwd" } },
+    });
+    vi.mocked(blobToUrl).mockReturnValue("file:///etc/passwd");
+    vi.mocked(fetchBlueskyAvatar).mockResolvedValue(undefined);
+
+    const data = await getCommunityCardData(stubDb(ROW), DID);
+    expect(data?.avatarUrl).toBeUndefined();
+  });
+});
+
+describe("isAllowedAvatarUrl", () => {
+  const PDS_HOST = "https://pds.example.com";
+
+  it("returns false when the URL does not parse", () => {
+    expect(isAllowedAvatarUrl("not a url", PDS_HOST)).toBe(false);
+  });
+
+  it("returns false for non-http(s) schemes", () => {
+    expect(isAllowedAvatarUrl("file:///etc/passwd", PDS_HOST)).toBe(false);
+  });
+
+  it("allows cdn.bsky.app regardless of pdsHost", () => {
+    expect(isAllowedAvatarUrl("https://cdn.bsky.app/img/a", PDS_HOST)).toBe(
+      true,
+    );
+  });
+
+  it("allows an exact pdsHost hostname match", () => {
+    expect(isAllowedAvatarUrl("https://pds.example.com/blob/x", PDS_HOST)).toBe(
+      true,
+    );
+  });
+
+  it("rejects a mismatched hostname", () => {
+    expect(isAllowedAvatarUrl("https://evil.example.com/x", PDS_HOST)).toBe(
+      false,
+    );
+  });
+
+  it("only allows cdn.bsky.app when pdsHost itself does not parse", () => {
+    expect(
+      isAllowedAvatarUrl("https://cdn.bsky.app/img/a", "not-a-valid-host"),
+    ).toBe(true);
+    expect(
+      isAllowedAvatarUrl("https://not-a-valid-host/img/a", "not-a-valid-host"),
+    ).toBe(false);
   });
 });

--- a/src/services/ogCard.test.ts
+++ b/src/services/ogCard.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getCommunityCardData } from "./ogCard";
+
+const DID = "did:plc:testcommunity000000001";
+
+const { getRecordMock } = vi.hoisted(() => ({ getRecordMock: vi.fn() }));
+
+vi.mock("@atproto/api", () => ({
+  BskyAgent: class {
+    api = { com: { atproto: { repo: { getRecord: getRecordMock } } } };
+  },
+}));
+
+vi.mock("./atproto", () => ({
+  resolvePdsEndpoint: vi.fn(async () => "https://pds.example.com"),
+}));
+
+vi.mock("../lib/avatar", () => ({
+  blobToUrl: vi.fn(() => undefined),
+  fetchBlueskyAvatar: vi.fn(async () => undefined),
+}));
+
+import { blobToUrl, fetchBlueskyAvatar } from "../lib/avatar";
+
+// Minimal chainable stand-in for the Kysely communities lookup.
+function stubDb(row: Record<string, unknown> | undefined) {
+  return {
+    selectFrom: () => ({
+      select: () => ({
+        where: () => ({ executeTakeFirst: async () => row }),
+      }),
+    }),
+  } as any;
+}
+
+const ROW = {
+  did: DID,
+  handle: "test-community.bsky.social",
+  display_name: "Test Community",
+  pds_host: "https://pds.example.com",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRecordMock.mockRejectedValue(new Error("RecordNotFound"));
+});
+
+describe("getCommunityCardData", () => {
+  it("returns null when the community does not exist", async () => {
+    expect(await getCommunityCardData(stubDb(undefined), DID)).toBeNull();
+  });
+
+  it("falls back to the DB display_name when there is no profile record", async () => {
+    const data = await getCommunityCardData(stubDb(ROW), DID);
+    expect(data).toEqual({
+      displayName: "Test Community",
+      description: undefined,
+      avatarUrl: undefined,
+    });
+  });
+
+  it("prefers the profile record displayName, description, and avatar", async () => {
+    getRecordMock.mockResolvedValue({
+      data: {
+        value: {
+          displayName: "Profile Name",
+          description: "A great community.",
+          avatar: {
+            $type: "blob",
+            ref: { $link: "bafyavatar" },
+            mimeType: "image/jpeg",
+          },
+        },
+      },
+    });
+    vi.mocked(blobToUrl).mockReturnValue(
+      "https://pds.example.com/blob/bafyavatar",
+    );
+
+    const data = await getCommunityCardData(stubDb(ROW), DID);
+    expect(data).toEqual({
+      displayName: "Profile Name",
+      description: "A great community.",
+      avatarUrl: "https://pds.example.com/blob/bafyavatar",
+    });
+  });
+
+  it("falls back to the Bluesky avatar when the profile has none", async () => {
+    vi.mocked(fetchBlueskyAvatar).mockResolvedValue(
+      "https://cdn.bsky.app/img/a@jpeg",
+    );
+    const data = await getCommunityCardData(stubDb(ROW), DID);
+    expect(data?.avatarUrl).toBe("https://cdn.bsky.app/img/a@jpeg");
+  });
+
+  it("uses the handle when display_name is empty", async () => {
+    const data = await getCommunityCardData(
+      stubDb({ ...ROW, display_name: "" }),
+      DID,
+    );
+    expect(data?.displayName).toBe("test-community.bsky.social");
+  });
+});

--- a/src/services/ogCard.ts
+++ b/src/services/ogCard.ts
@@ -18,6 +18,52 @@ interface ProfileRecordValue {
 }
 
 /**
+ * Deny-by-default vetting for avatar URLs before they're passed to a
+ * server-side fetch. `getCommunityCardData` sources avatar URLs from data a
+ * community controls (its own profile record) or from Bluesky's CDN, and
+ * the profile record's `avatar` field can be an arbitrary string (see
+ * `blobToUrl`). Without this check a malicious community could point the
+ * crawler-triggered avatar fetch at an internal host or the cloud metadata
+ * endpoint (SSRF), with the response re-served as a publicly cacheable PNG.
+ *
+ * Only allows:
+ *  - `cdn.bsky.app` (the public Bluesky avatar CDN), or
+ *  - the exact hostname of the community's own registered `pdsHost`.
+ *
+ * If `pdsHost` itself doesn't parse as a URL, only `cdn.bsky.app` is
+ * allowed.
+ */
+export function isAllowedAvatarUrl(url: string, pdsHost: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+
+  if (parsed.hostname === "cdn.bsky.app") return true;
+
+  try {
+    const pds = new URL(pdsHost);
+    return parsed.hostname === pds.hostname;
+  } catch {
+    return false;
+  }
+}
+
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "(unparseable)";
+  }
+}
+
+/**
  * Minimal community lookup for OG share cards. Reads the DB row plus the
  * public community profile record (no app-password agent — crawler traffic
  * must never depend on community credentials). Returns null when the
@@ -51,6 +97,13 @@ export async function getCommunityCardData(
     if (profile.displayName) displayName = profile.displayName;
     if (profile.description) description = profile.description;
     avatarUrl = blobToUrl(profile.avatar, did, community.pds_host);
+    if (avatarUrl && !isAllowedAvatarUrl(avatarUrl, community.pds_host)) {
+      logger.warn(
+        { did, host: safeHostname(avatarUrl) },
+        "Rejected community profile avatar URL (not an allowed host)",
+      );
+      avatarUrl = undefined;
+    }
   } catch (err) {
     // Profile record missing or PDS unreachable — card still renders.
     logger.debug(
@@ -60,7 +113,17 @@ export async function getCommunityCardData(
   }
 
   if (!avatarUrl) {
-    avatarUrl = await fetchBlueskyAvatar(did);
+    const blueskyAvatar = await fetchBlueskyAvatar(did);
+    if (blueskyAvatar) {
+      if (isAllowedAvatarUrl(blueskyAvatar, community.pds_host)) {
+        avatarUrl = blueskyAvatar;
+      } else {
+        logger.warn(
+          { did, host: safeHostname(blueskyAvatar) },
+          "Rejected Bluesky avatar URL (not an allowed host)",
+        );
+      }
+    }
   }
 
   return { displayName, description, avatarUrl };

--- a/src/services/ogCard.ts
+++ b/src/services/ogCard.ts
@@ -1,0 +1,67 @@
+import { BskyAgent } from "@atproto/api";
+import type { Kysely } from "kysely";
+import type { Database } from "../db";
+import { resolvePdsEndpoint } from "./atproto";
+import { blobToUrl, fetchBlueskyAvatar } from "../lib/avatar";
+import { logger } from "../lib/logger";
+
+export interface CommunityCardData {
+  displayName: string;
+  description?: string;
+  avatarUrl?: string;
+}
+
+interface ProfileRecordValue {
+  displayName?: string;
+  description?: string;
+  avatar?: unknown;
+}
+
+/**
+ * Minimal community lookup for OG share cards. Reads the DB row plus the
+ * public community profile record (no app-password agent — crawler traffic
+ * must never depend on community credentials). Returns null when the
+ * community doesn't exist.
+ */
+export async function getCommunityCardData(
+  db: Kysely<Database>,
+  did: string,
+): Promise<CommunityCardData | null> {
+  const community = await db
+    .selectFrom("communities")
+    .select(["did", "handle", "display_name", "pds_host"])
+    .where("did", "=", did)
+    .executeTakeFirst();
+
+  if (!community) return null;
+
+  let displayName = community.display_name || community.handle;
+  let description: string | undefined;
+  let avatarUrl: string | undefined;
+
+  try {
+    const pdsUrl = await resolvePdsEndpoint(did, community.pds_host);
+    const agent = new BskyAgent({ service: pdsUrl });
+    const record = await agent.api.com.atproto.repo.getRecord({
+      repo: did,
+      collection: "community.opensocial.profile",
+      rkey: "self",
+    });
+    const profile = record.data.value as ProfileRecordValue;
+    if (profile.displayName) displayName = profile.displayName;
+    if (profile.description) description = profile.description;
+    avatarUrl = blobToUrl(profile.avatar, did, community.pds_host);
+  } catch (err) {
+    // Profile record missing or PDS unreachable — card still renders.
+    logger.debug(
+      { error: err, did },
+      "No community profile record for OG card",
+    );
+  }
+
+  if (!avatarUrl) {
+    avatarUrl = await fetchBlueskyAvatar(did);
+  }
+
+  return { displayName, description, avatarUrl };
+}

--- a/src/services/ogImage.test.ts
+++ b/src/services/ogImage.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { renderCommunityCard, renderDefaultCard } from "./ogImage";
+
+// A minimal valid 1x1 white JPEG for the avatar-embedding path.
+const TINY_JPEG_DATA_URI =
+  "data:image/jpeg;base64," +
+  "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigD//2Q==";
+
+function pngDimensions(buf: Buffer): { width: number; height: number } {
+  // PNG signature is 8 bytes; IHDR width/height are big-endian at 16/20.
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+function expectValidCardPng(buf: Buffer) {
+  expect(buf.subarray(0, 8)).toEqual(
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  );
+  expect(pngDimensions(buf)).toEqual({ width: 1200, height: 630 });
+}
+
+describe("renderCommunityCard", () => {
+  it("renders a 1200x630 PNG with an avatar", async () => {
+    const buf = await renderCommunityCard({
+      displayName: "ATProtocol Developers",
+      avatarDataUri: TINY_JPEG_DATA_URI,
+    });
+    expectValidCardPng(buf);
+  });
+
+  it("renders a 1200x630 PNG without an avatar (monogram fallback)", async () => {
+    const buf = await renderCommunityCard({
+      displayName: "ATProtocol Developers",
+    });
+    expectValidCardPng(buf);
+  });
+
+  it("handles very long community names without throwing", async () => {
+    const buf = await renderCommunityCard({
+      displayName:
+        "The Extremely Long-Winded Society of People Who Never Abbreviate Anything At All Ever",
+    });
+    expectValidCardPng(buf);
+  });
+
+  it("handles names with characters satori must escape", async () => {
+    const buf = await renderCommunityCard({
+      displayName: 'Rock & <Roll> "Club"',
+    });
+    expectValidCardPng(buf);
+  });
+});
+
+describe("renderDefaultCard", () => {
+  it("renders the generic 1200x630 fallback card", async () => {
+    const buf = await renderDefaultCard();
+    expectValidCardPng(buf);
+  });
+});

--- a/src/services/ogImage.test.ts
+++ b/src/services/ogImage.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { renderCommunityCard, renderDefaultCard } from "./ogImage";
+import {
+  buildCommunityCardTree,
+  renderCommunityCard,
+  renderDefaultCard,
+} from "./ogImage";
 
 // A minimal valid 1x1 white JPEG for the avatar-embedding path.
 const TINY_JPEG_DATA_URI =
@@ -47,6 +51,38 @@ describe("renderCommunityCard", () => {
       displayName: 'Rock & <Roll> "Club"',
     });
     expectValidCardPng(buf);
+  });
+});
+
+describe("buildCommunityCardTree (headline overflow regression guard)", () => {
+  // This test intentionally pins the layout mechanism that prevents the
+  // headline from overflowing the canvas: the text column must have the
+  // exact derived width (canvas minus padding, avatar, and gap), and the
+  // headline must combine display: "block" with lineClamp — satori only
+  // applies lineClamp to block elements, so dropping either silently
+  // reintroduces the overflow. Indexing into the known tree shape is
+  // deliberate; if the layout structure changes, update this test alongside.
+  it("pins the fixed-width text column and block/lineClamp headline", () => {
+    const tree = buildCommunityCardTree({
+      displayName:
+        "The Extremely Long-Winded Society of People Who Never Abbreviate Anything At All Ever",
+    });
+
+    // Root children: [avatar, text column, bottom accent bar]
+    const children = tree.props.children as Array<{
+      props: { style: Record<string, unknown>; children?: unknown };
+    }>;
+    const textColumn = children[1];
+    expect(textColumn.props.style.width).toBe(1200 - 2 * 96 - 300 - 72);
+
+    // Text column children: [eyebrow, headline, subline]
+    const columnChildren = textColumn.props.children as Array<{
+      props: { style: Record<string, unknown>; children?: unknown };
+    }>;
+    const headline = columnChildren[1];
+    expect(headline.props.children).toContain("Extremely Long-Winded");
+    expect(headline.props.style.display).toBe("block");
+    expect(headline.props.style.lineClamp).toBe(2);
   });
 });
 

--- a/src/services/ogImage.ts
+++ b/src/services/ogImage.ts
@@ -1,0 +1,214 @@
+import { readFileSync } from "fs";
+import satori from "satori";
+import { Resvg } from "@resvg/resvg-js";
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+// Approved "warm cream" palette (spec: 2026-07-10-og-share-cards-design.md)
+const BG_GRADIENT = "linear-gradient(135deg, #FAF8F6 0%, #F3EFE9 100%)";
+const TERRACOTTA = "#C2703E";
+const HEADLINE_COLOR = "#2A2420";
+const SUBLINE_COLOR = "#7A6F62";
+const MONOGRAM_BG = "#F9E1D0";
+
+type SatoriFont = {
+  name: string;
+  data: Buffer;
+  weight: 400 | 700;
+  style: "normal";
+};
+
+let fonts: SatoriFont[] | null = null;
+
+/** Fonts ship in @fontsource packages (woff — satori-compatible); loaded once. */
+function loadFonts(): SatoriFont[] {
+  if (!fonts) {
+    fonts = [
+      {
+        name: "Vollkorn",
+        data: readFileSync(
+          require.resolve("@fontsource/vollkorn/files/vollkorn-latin-700-normal.woff"),
+        ),
+        weight: 700,
+        style: "normal",
+      },
+      {
+        name: "Inter",
+        data: readFileSync(
+          require.resolve("@fontsource/inter/files/inter-latin-400-normal.woff"),
+        ),
+        weight: 400,
+        style: "normal",
+      },
+      {
+        name: "Inter",
+        data: readFileSync(
+          require.resolve("@fontsource/inter/files/inter-latin-700-normal.woff"),
+        ),
+        weight: 700,
+        style: "normal",
+      },
+    ];
+  }
+  return fonts;
+}
+
+// Satori element helper — plain object trees, no JSX.
+function el(type: string, style: Record<string, unknown>, children?: unknown) {
+  return {
+    type,
+    props: { style, ...(children !== undefined ? { children } : {}) },
+  };
+}
+
+function headlineFontSize(name: string): number {
+  if (name.length <= 20) return 68;
+  if (name.length <= 40) return 56;
+  return 48;
+}
+
+function avatarNode(avatarDataUri: string | undefined, displayName: string) {
+  const ring = `10px solid ${TERRACOTTA}`;
+  if (avatarDataUri) {
+    return {
+      type: "img",
+      props: {
+        src: avatarDataUri,
+        width: 300,
+        height: 300,
+        style: {
+          width: 300,
+          height: 300,
+          borderRadius: 150,
+          border: ring,
+          objectFit: "cover",
+          flexShrink: 0,
+        },
+      },
+    };
+  }
+  // Monogram fallback: first letter in a terracotta-ringed circle.
+  const letter = (displayName.trim()[0] || "?").toUpperCase();
+  return el(
+    "div",
+    {
+      width: 300,
+      height: 300,
+      borderRadius: 150,
+      border: ring,
+      backgroundColor: MONOGRAM_BG,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      fontFamily: "Vollkorn",
+      fontWeight: 700,
+      fontSize: 140,
+      color: TERRACOTTA,
+      flexShrink: 0,
+    },
+    letter,
+  );
+}
+
+async function renderCard(opts: {
+  headline: string;
+  headlineFontSize: number;
+  subline: string;
+  avatar: unknown;
+}): Promise<Buffer> {
+  const tree = el(
+    "div",
+    {
+      width: WIDTH,
+      height: HEIGHT,
+      display: "flex",
+      alignItems: "center",
+      gap: 72,
+      padding: "0 96px",
+      backgroundImage: BG_GRADIENT,
+      position: "relative",
+    },
+    [
+      opts.avatar,
+      el("div", { display: "flex", flexDirection: "column", flexGrow: 1 }, [
+        el(
+          "div",
+          {
+            fontFamily: "Inter",
+            fontWeight: 700,
+            fontSize: 26,
+            letterSpacing: "0.18em",
+            color: TERRACOTTA,
+            marginBottom: 20,
+          },
+          "OPEN SOCIAL",
+        ),
+        el(
+          "div",
+          {
+            fontFamily: "Vollkorn",
+            fontWeight: 700,
+            fontSize: opts.headlineFontSize,
+            color: HEADLINE_COLOR,
+            lineHeight: 1.15,
+            letterSpacing: "-0.02em",
+            lineClamp: 2,
+          },
+          opts.headline,
+        ),
+        el(
+          "div",
+          {
+            fontFamily: "Inter",
+            fontWeight: 400,
+            fontSize: 38,
+            color: SUBLINE_COLOR,
+            marginTop: 20,
+          },
+          opts.subline,
+        ),
+      ]),
+      // Terracotta accent bar along the bottom edge.
+      el("div", {
+        position: "absolute",
+        left: 0,
+        bottom: 0,
+        width: WIDTH,
+        height: 16,
+        backgroundColor: TERRACOTTA,
+      }),
+    ],
+  );
+
+  const svg = await satori(tree as any, {
+    width: WIDTH,
+    height: HEIGHT,
+    fonts: loadFonts(),
+  });
+  const resvg = new Resvg(svg, { fitTo: { mode: "width", value: WIDTH } });
+  return resvg.render().asPng();
+}
+
+/** The per-community share card: avatar + "Join {name}" + "on Open Social". */
+export async function renderCommunityCard(opts: {
+  displayName: string;
+  avatarDataUri?: string;
+}): Promise<Buffer> {
+  return renderCard({
+    headline: `Join ${opts.displayName}`,
+    headlineFontSize: headlineFontSize(opts.displayName),
+    subline: "on Open Social",
+    avatar: avatarNode(opts.avatarDataUri, opts.displayName),
+  });
+}
+
+/** Generic fallback card for the web app's static og:image tag. */
+export async function renderDefaultCard(): Promise<Buffer> {
+  return renderCard({
+    headline: "Open Social",
+    headlineFontSize: 68,
+    subline: "Communities for the open social web",
+    avatar: avatarNode(undefined, "Open Social"),
+  });
+}

--- a/src/services/ogImage.ts
+++ b/src/services/ogImage.ts
@@ -131,7 +131,9 @@ async function renderCard(opts: {
     },
     [
       opts.avatar,
-      el("div", { display: "flex", flexDirection: "column", flexGrow: 1 }, [
+      // Fixed width so the headline wraps/clamps inside the padded content
+      // area: 1200 − 2×96 padding − 300 avatar − 72 gap = 636.
+      el("div", { display: "flex", flexDirection: "column", width: 636 }, [
         el(
           "div",
           {
@@ -153,6 +155,8 @@ async function renderCard(opts: {
             color: HEADLINE_COLOR,
             lineHeight: 1.15,
             letterSpacing: "-0.02em",
+            // Satori only clamps block elements with a single string child.
+            display: "block",
             lineClamp: 2,
           },
           opts.headline,

--- a/src/services/ogImage.ts
+++ b/src/services/ogImage.ts
@@ -5,6 +5,14 @@ import { Resvg } from "@resvg/resvg-js";
 const WIDTH = 1200;
 const HEIGHT = 630;
 
+// Layout geometry. TEXT_COLUMN_WIDTH is derived so the headline always
+// wraps/clamps inside the padded content area — if any of these change,
+// the column width follows automatically.
+const PADDING_X = 96;
+const AVATAR_SIZE = 300;
+const COLUMN_GAP = 72;
+const TEXT_COLUMN_WIDTH = WIDTH - 2 * PADDING_X - AVATAR_SIZE - COLUMN_GAP; // 636
+
 // Approved "warm cream" palette (spec: 2026-07-10-og-share-cards-design.md)
 const BG_GRADIENT = "linear-gradient(135deg, #FAF8F6 0%, #F3EFE9 100%)";
 const TERRACOTTA = "#C2703E";
@@ -54,11 +62,29 @@ function loadFonts(): SatoriFont[] {
   return fonts;
 }
 
-// Satori element helper — plain object trees, no JSX.
-function el(type: string, style: Record<string, unknown>, children?: unknown) {
+export type SatoriNode = {
+  type: string;
+  props: Record<string, unknown> & {
+    style: Record<string, unknown>;
+    children?: unknown;
+  };
+};
+
+// Satori element helper — plain object trees, no JSX. `extraProps` covers
+// non-style attributes like an <img>'s src/width/height.
+function el(
+  type: string,
+  style: Record<string, unknown>,
+  children?: unknown,
+  extraProps?: Record<string, unknown>,
+): SatoriNode {
   return {
     type,
-    props: { style, ...(children !== undefined ? { children } : {}) },
+    props: {
+      ...extraProps,
+      style,
+      ...(children !== undefined ? { children } : {}),
+    },
   };
 }
 
@@ -68,34 +94,34 @@ function headlineFontSize(name: string): number {
   return 48;
 }
 
-function avatarNode(avatarDataUri: string | undefined, displayName: string) {
+function avatarNode(
+  avatarDataUri: string | undefined,
+  displayName: string,
+): SatoriNode {
   const ring = `10px solid ${TERRACOTTA}`;
   if (avatarDataUri) {
-    return {
-      type: "img",
-      props: {
-        src: avatarDataUri,
-        width: 300,
-        height: 300,
-        style: {
-          width: 300,
-          height: 300,
-          borderRadius: 150,
-          border: ring,
-          objectFit: "cover",
-          flexShrink: 0,
-        },
+    return el(
+      "img",
+      {
+        width: AVATAR_SIZE,
+        height: AVATAR_SIZE,
+        borderRadius: AVATAR_SIZE / 2,
+        border: ring,
+        objectFit: "cover",
+        flexShrink: 0,
       },
-    };
+      undefined,
+      { src: avatarDataUri, width: AVATAR_SIZE, height: AVATAR_SIZE },
+    );
   }
   // Monogram fallback: first letter in a terracotta-ringed circle.
   const letter = (displayName.trim()[0] || "?").toUpperCase();
   return el(
     "div",
     {
-      width: 300,
-      height: 300,
-      borderRadius: 150,
+      width: AVATAR_SIZE,
+      height: AVATAR_SIZE,
+      borderRadius: AVATAR_SIZE / 2,
       border: ring,
       backgroundColor: MONOGRAM_BG,
       display: "flex",
@@ -111,68 +137,72 @@ function avatarNode(avatarDataUri: string | undefined, displayName: string) {
   );
 }
 
-async function renderCard(opts: {
+function buildCardTree(opts: {
   headline: string;
   headlineFontSize: number;
   subline: string;
-  avatar: unknown;
-}): Promise<Buffer> {
-  const tree = el(
+  avatar: SatoriNode;
+}): SatoriNode {
+  return el(
     "div",
     {
       width: WIDTH,
       height: HEIGHT,
       display: "flex",
       alignItems: "center",
-      gap: 72,
-      padding: "0 96px",
+      gap: COLUMN_GAP,
+      padding: `0 ${PADDING_X}px`,
       backgroundImage: BG_GRADIENT,
       position: "relative",
     },
     [
       opts.avatar,
-      // Fixed width so the headline wraps/clamps inside the padded content
-      // area: 1200 − 2×96 padding − 300 avatar − 72 gap = 636.
-      el("div", { display: "flex", flexDirection: "column", width: 636 }, [
-        el(
-          "div",
-          {
-            fontFamily: "Inter",
-            fontWeight: 700,
-            fontSize: 26,
-            letterSpacing: "0.18em",
-            color: TERRACOTTA,
-            marginBottom: 20,
-          },
-          "OPEN SOCIAL",
-        ),
-        el(
-          "div",
-          {
-            fontFamily: "Vollkorn",
-            fontWeight: 700,
-            fontSize: opts.headlineFontSize,
-            color: HEADLINE_COLOR,
-            lineHeight: 1.15,
-            letterSpacing: "-0.02em",
-            // Satori only clamps block elements with a single string child.
-            display: "block",
-            lineClamp: 2,
-          },
-          opts.headline,
-        ),
-        el(
-          "div",
-          {
-            fontFamily: "Inter",
-            fontWeight: 400,
-            fontSize: 38,
-            color: SUBLINE_COLOR,
-            marginTop: 20,
-          },
-          opts.subline,
-        ),
-      ]),
+      // Fixed width so the headline wraps/clamps inside the padded content area.
+      el(
+        "div",
+        { display: "flex", flexDirection: "column", width: TEXT_COLUMN_WIDTH },
+        [
+          el(
+            "div",
+            {
+              fontFamily: "Inter",
+              fontWeight: 700,
+              fontSize: 26,
+              letterSpacing: "0.18em",
+              color: TERRACOTTA,
+              marginBottom: 20,
+            },
+            "OPEN SOCIAL",
+          ),
+          el(
+            "div",
+            {
+              fontFamily: "Vollkorn",
+              fontWeight: 700,
+              fontSize: opts.headlineFontSize,
+              color: HEADLINE_COLOR,
+              lineHeight: 1.15,
+              letterSpacing: "-0.02em",
+              // Satori only clamps block elements with a single string child;
+              // lineClamp has no effect without display: "block".
+              display: "block",
+              lineClamp: 2,
+            },
+            opts.headline,
+          ),
+          el(
+            "div",
+            {
+              fontFamily: "Inter",
+              fontWeight: 400,
+              fontSize: 38,
+              color: SUBLINE_COLOR,
+              marginTop: 20,
+            },
+            opts.subline,
+          ),
+        ],
+      ),
       // Terracotta accent bar along the bottom edge.
       el("div", {
         position: "absolute",
@@ -184,7 +214,9 @@ async function renderCard(opts: {
       }),
     ],
   );
+}
 
+async function renderCard(tree: SatoriNode): Promise<Buffer> {
   const svg = await satori(tree as any, {
     width: WIDTH,
     height: HEIGHT,
@@ -194,12 +226,16 @@ async function renderCard(opts: {
   return resvg.render().asPng();
 }
 
-/** The per-community share card: avatar + "Join {name}" + "on Open Social". */
-export async function renderCommunityCard(opts: {
+/**
+ * The satori layout tree used by renderCommunityCard. Exported so tests can
+ * structurally pin the overflow-prevention mechanism (fixed-width text column
+ * + block/lineClamp headline) without decoding rendered pixels.
+ */
+export function buildCommunityCardTree(opts: {
   displayName: string;
   avatarDataUri?: string;
-}): Promise<Buffer> {
-  return renderCard({
+}): SatoriNode {
+  return buildCardTree({
     headline: `Join ${opts.displayName}`,
     headlineFontSize: headlineFontSize(opts.displayName),
     subline: "on Open Social",
@@ -207,12 +243,22 @@ export async function renderCommunityCard(opts: {
   });
 }
 
+/** The per-community share card: avatar + "Join {name}" + "on Open Social". */
+export async function renderCommunityCard(opts: {
+  displayName: string;
+  avatarDataUri?: string;
+}): Promise<Buffer> {
+  return renderCard(buildCommunityCardTree(opts));
+}
+
 /** Generic fallback card for the web app's static og:image tag. */
 export async function renderDefaultCard(): Promise<Buffer> {
-  return renderCard({
-    headline: "Open Social",
-    headlineFontSize: 68,
-    subline: "Communities for the open social web",
-    avatar: avatarNode(undefined, "Open Social"),
-  });
+  return renderCard(
+    buildCardTree({
+      headline: "Open Social",
+      headlineFontSize: 68,
+      subline: "Communities for the open social web",
+      avatar: avatarNode(undefined, "Open Social"),
+    }),
+  );
 }


### PR DESCRIPTION
## Summary

Adds two public endpoints that give community share links rich Open Graph previews ("Join {name} on Open Social" + community avatar) in Slack/Discord/iMessage/Bluesky/X:

- `GET /communities/:did/share` — HTML page with OG meta tags (dynamic title, community description, `twitter:card`) that instantly redirects humans to `app.opensocial.community/communities/:did?action=join`, preserving the join flow. This is the URL the web app's Share button now copies.
- `GET /communities/:did/og-image` — 1200×630 PNG card rendered with satori + @resvg/resvg-js in the warm-cream brand style (Vollkorn headline, terracotta accents, avatar in a ringed circle, monogram fallback), with an in-memory TTL cache and `Cache-Control: public, max-age=3600`.

## Implementation notes

- **New deps** (`dependencies`, Docker-prod compatible, no Dockerfile changes): `satori`, `@resvg/resvg-js`, `@fontsource/vollkorn`, `@fontsource/inter` — fonts load from node_modules at runtime.
- **WebP handling**: satori/resvg can't decode WebP; `cdn.bsky.app` URLs get an `@jpeg` transcode suffix, and magic-byte sniffing rejects anything undecodable (falls back to monogram).
- **Security**: avatar fetching is guarded by a deny-by-default host allowlist (community's registered PDS + cdn.bsky.app, http/https only, `redirect: "error"`) against SSRF; all share-page interpolations are HTML-escaped (incl. a Host-header injection regression test); both routes use the existing rate limiter.
- **Long names**: headline font steps down by length and clamps to 2 lines with ellipsis; a structural regression test pins the clamp mechanism.
- Lookup uses only public PDS reads — crawler traffic never depends on community app-password credentials.

## Testing

- 37 unit/route tests across the four new modules (TDD throughout), full suite green (1 pre-existing Postgres-dependent failure unrelated).
- Live end-to-end smoke test: real app + throwaway Postgres + the real ATProtocol Developers community — correct tags (live PDS description), real avatar rendered via the CDN transcode path, 404s, exact cache headers.
- Rendered cards visually verified: normal, long-name, tiny-name, monogram, and default variants.

Companion PR in open-social-web updates the Share button and adds static fallback OG tags.

Spec/plan: `docs/superpowers/specs/2026-07-10-og-share-cards-design.md` and `docs/superpowers/plans/2026-07-10-og-share-cards.md` in the open-social-web repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Kq42pMzTTkuQY6d4KSqgt