### PR TITLE
ci: deploy to open-social-2 in the new container apps environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,6 @@ jobs:
                   docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/open-social:${{ github.sha }}
             - run: |
                   az containerapp update \
-                    --name open-social \
+                    --name open-social-2 \
                     --resource-group open-collective-social \
                     --image ${{ secrets.REGISTRY_LOGIN_SERVER }}/open-social:${{ github.sha }}


### PR DESCRIPTION
The `social-apps-env` environment's ingress has been dropping most inbound connections since 2026-07-11 01:20 UTC (#89). Production has been migrated to a fresh environment `social-apps-env-2` with the app recreated as `open-social-2` (same image, config, and secrets; registry pulls now use managed identity instead of admin credentials).

This points CI at the new app so future merges to main deploy to the right place.

**Merge after** the `api.opensocial.community` cutover to `open-social-2` is confirmed. The old `open-social` app is intentionally left in place for the Azure support investigation and as rollback.

Related: #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWwfFSsMn7ADKeERgK7TqF